### PR TITLE
Add @Nullable annotation to public APIs (#5044)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,16 @@ While we havn't described our code style yet, please just follow the existing st
 
 For source code written in C++, we format it using `clang-format`. You can use the [plugin](https://plugins.jetbrains.com/plugin/8396-clangformatij): mark the entire file and right-click to execute `clang-format` before committing any changes. Of course, if you don't use Android Studio to edit C++ code, run `clang-format` on the command-line.
 
+### Nullability by Annotataion
+
+To improve code quality and usability in Kotlin, nullability of parameters and return types must be annotated with JSR305 annotations.
+
+If a parameter is nullable, you must add `@Nullable` annotation to the parameter. On the other hand, if a parameter is non-null, you don't need to add `@Nonnull` annotation since all parameters are treated as `@Nonnull` by default.
+
+For return types, there is no default nullability. If a method can return `null` as a return value, you must add `@Nullable` annotation to the return type. Currently, `Nonnull` annotation is not mandatory if the method never return `null`.
+
+When you add a new package, you must add `package-info.java` and add `@javax.annotation.ParametersAreNonnullByDefault` to the package. Please note that you can't add multiple `package-info.java` in the same package but different location (for example, main and androidTest). When you add a package to both main and androidTest, you only need to add `package-info.java` to main.
+
 ### Unit Tests
 
 All PR's must be accompanied by related unit tests. All bug fixes must have a unit test proving that the bug is fixed.

--- a/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
+++ b/examples/kotlinExample/src/main/kotlin/io/realm/examples/kotlin/KotlinExampleActivity.kt
@@ -112,7 +112,7 @@ class KotlinExampleActivity : Activity() {
         showStatus("\nPerforming basic Query operation...")
         showStatus("Number of persons: ${realm.where(Person::class.java).count()}")
 
-        val results = realm.where(Person::class.java).equalTo("age", 99).findAll()
+        val results = realm.where(Person::class.java).equalTo("age", 99.toInt()).findAll()
 
         showStatus("Size of result set: " + results.size)
     }

--- a/realm/realm-library/src/androidTest/java/io/realm/instrumentation/package-info.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/instrumentation/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.instrumentation;

--- a/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
+++ b/realm/realm-library/src/androidTest/java/io/realm/internal/RealmNotifierTests.java
@@ -27,6 +27,8 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmChangeListener;
 import io.realm.RealmConfiguration;
 import io.realm.internal.android.AndroidRealmNotifier;
@@ -52,7 +54,7 @@ public class RealmNotifierTests {
         }
 
         @Override
-        public void checkCanDeliverNotification(String exceptionMessage) {
+        public void checkCanDeliverNotification(@Nullable String exceptionMessage) {
         }
 
         @Override

--- a/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
+++ b/realm/realm-library/src/androidTestObjectServer/java/io/realm/SyncUserTests.java
@@ -285,6 +285,7 @@ public class SyncUserTests {
         SyncUser user = createTestUser();
 
         thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions
         user.changePassword(null);
     }
 
@@ -293,6 +294,7 @@ public class SyncUserTests {
         SyncUser user = createTestUser();
 
         thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions
         user.changePassword(null, "new-password");
     }
 
@@ -301,7 +303,7 @@ public class SyncUserTests {
         SyncUser user = createTestUser();
 
         thrown.expect(IllegalStateException.class);
-        user.changePasswordAsync(null, new SyncUser.Callback() {
+        user.changePasswordAsync("password", new SyncUser.Callback() {
             @Override
             public void onSuccess(SyncUser user) {
                 fail();
@@ -338,6 +340,7 @@ public class SyncUserTests {
         SyncUser user = createTestUser();
 
         thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions
         user.changePasswordAsync("new-password", null);
     }
 
@@ -347,6 +350,7 @@ public class SyncUserTests {
         SyncUser user = createTestUser();
 
         thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions
         user.changePasswordAsync("user-id", "new-password", null);
     }
 

--- a/realm/realm-library/src/main/java/io/realm/BaseRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/BaseRealm.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.annotation.Nullable;
+
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
 import io.realm.exceptions.RealmMigrationNeededException;
@@ -152,6 +154,7 @@ abstract class BaseRealm implements Closeable {
     }
 
     protected <T extends BaseRealm> void addListener(RealmChangeListener<T> listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
@@ -170,6 +173,7 @@ abstract class BaseRealm implements Closeable {
      * @see io.realm.RealmChangeListener
      */
     protected <T extends BaseRealm> void removeListener(RealmChangeListener<T> listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
@@ -224,7 +228,12 @@ abstract class BaseRealm implements Closeable {
      * destination file.
      */
     public void writeCopyTo(File destination) {
-        writeEncryptedCopyTo(destination, null);
+        //noinspection ConstantConditions
+        if (destination == null) {
+            throw new IllegalArgumentException("The destination argument cannot be null");
+        }
+        checkIfValid();
+        sharedRealm.writeCopy(destination, null);
     }
 
     /**
@@ -243,6 +252,7 @@ abstract class BaseRealm implements Closeable {
      * destination file.
      */
     public void writeEncryptedCopyTo(File destination, byte[] key) {
+        //noinspection ConstantConditions
         if (destination == null) {
             throw new IllegalArgumentException("The destination argument cannot be null");
         }
@@ -506,7 +516,7 @@ abstract class BaseRealm implements Closeable {
 
     // Used by RealmList/RealmResults, to create RealmObject from a Collection.
     // Invariant: if dynamicClassName != null -> clazz == DynamicRealmObject
-    <E extends RealmModel> E get(Class<E> clazz, String dynamicClassName, UncheckedRow row) {
+    <E extends RealmModel> E get(@Nullable Class<E> clazz, @Nullable String dynamicClassName, UncheckedRow row) {
         final boolean isDynamicRealmObject = dynamicClassName != null;
 
         E result;
@@ -514,6 +524,8 @@ abstract class BaseRealm implements Closeable {
             //noinspection unchecked
             result = (E) new DynamicRealmObject(this, CheckedRow.getFromRow(row));
         } else {
+            // 'clazz' is non-null when 'dynamicClassName' is null.
+            //noinspection ConstantConditions
             result = configuration.getSchemaMediator().newInstance(clazz, this, row, getSchema().getColumnInfo(clazz),
                     false, Collections.<String>emptyList());
         }
@@ -530,8 +542,10 @@ abstract class BaseRealm implements Closeable {
     // Used by RealmList/RealmResults
     // Invariant: if dynamicClassName != null -> clazz == DynamicRealmObject
     // TODO: Remove this after RealmList is backed by OS Results.
-    <E extends RealmModel> E get(Class<E> clazz, String dynamicClassName, long rowIndex) {
+    <E extends RealmModel> E get(@Nullable Class<E> clazz, @Nullable String dynamicClassName, long rowIndex) {
         final boolean isDynamicRealmObject = dynamicClassName != null;
+        // 'clazz' is non-null when 'dynamicClassName' is null.
+        //noinspection ConstantConditions
         final Table table = isDynamicRealmObject ? getSchema().getTable(dynamicClassName) : getSchema().getTable(clazz);
 
         E result;
@@ -605,12 +619,13 @@ abstract class BaseRealm implements Closeable {
      * @param callback callback for specific Realm type behaviors.
      * @param cause which triggers this migration.
      * @throws FileNotFoundException if the Realm file doesn't exist.
-     * @throws IllegalArgumentException if the provided configuration is a {@link SyncConfiguration}.
+     * @throws IllegalArgumentException if the provided configuration is a {@code SyncConfiguration}.
      */
-    protected static void migrateRealm(final RealmConfiguration configuration, final RealmMigration migration,
-            final MigrationCallback callback, final RealmMigrationNeededException cause)
+    protected static void migrateRealm(final RealmConfiguration configuration, @Nullable final RealmMigration migration,
+            final MigrationCallback callback, @Nullable final RealmMigrationNeededException cause)
             throws FileNotFoundException {
 
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException("RealmConfiguration must be provided");
         }

--- a/realm/realm-library/src/main/java/io/realm/CompactOnLaunchCallback.java
+++ b/realm/realm-library/src/main/java/io/realm/CompactOnLaunchCallback.java
@@ -23,7 +23,7 @@ import io.realm.internal.Keep;
  * the instance is returned.
  * <p>
  * Note that compacting a file can take a while, so compacting should generally only be done on a background thread or
- * when used in combination with {@link Realm#getInstanceAsync(RealmConfiguration, Realm.Callback)}.
+ * when used in combination with {@link Realm#getInstanceAsync(RealmConfiguration, io.realm.Realm.Callback)}.
  */
 @Keep
 public interface CompactOnLaunchCallback {

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealm.java
@@ -72,6 +72,7 @@ public class DynamicRealm extends BaseRealm {
      * @see RealmConfiguration for details on how to configure a Realm.
      */
     public static DynamicRealm getInstance(RealmConfiguration configuration) {
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException("A non-null RealmConfiguration must be provided");
         }
@@ -93,6 +94,7 @@ public class DynamicRealm extends BaseRealm {
      */
     public static RealmAsyncTask getInstanceAsync(RealmConfiguration configuration,
                                                   Callback callback) {
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException("A non-null RealmConfiguration must be provided");
         }
@@ -215,6 +217,7 @@ public class DynamicRealm extends BaseRealm {
      * @throws IllegalArgumentException if the {@code transaction} is {@code null}.
      */
     public void executeTransaction(Transaction transaction) {
+        //noinspection ConstantConditions
         if (transaction == null) {
             throw new IllegalArgumentException("Transaction should not be null");
         }
@@ -299,4 +302,3 @@ public class DynamicRealm extends BaseRealm {
         }
     }
 }
-

--- a/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/DynamicRealmObject.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.realm.exceptions.RealmException;
@@ -48,6 +49,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
      * @throws IllegalArgumentException if object isn't managed by Realm or is a {@link DynamicRealmObject} already.
      */
     public DynamicRealmObject(RealmModel obj) {
+        //noinspection ConstantConditions
         if (obj == null) {
             throw new IllegalArgumentException("A non-null object must be provided.");
         }
@@ -347,6 +349,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         try {
             LinkView linkView = proxyState.getRow$realm().getLinkList(columnIndex);
+            //noinspection ConstantConditions
+            @Nonnull
             String className = linkView.getTargetTable().getClassName();
             return new RealmList<>(className, linkView, proxyState.getRealm$realm());
         } catch (IllegalArgumentException e) {
@@ -395,7 +399,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
     public boolean hasField(String fieldName) {
         proxyState.getRealm$realm().checkIfValid();
 
-        //noinspection SimplifiableIfStatement
+        //noinspection SimplifiableIfStatement,ConstantConditions
         if (fieldName == null || fieldName.isEmpty()) {
             return false;
         }
@@ -619,7 +623,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
      * @throws IllegalArgumentException if field name doesn't exist or field isn't a String field.
      * @throws RealmException if the field is a {@link io.realm.annotations.PrimaryKey} field.
      */
-    public void setString(String fieldName, String value) {
+    public void setString(String fieldName, @Nullable String value) {
         proxyState.getRealm$realm().checkIfValid();
 
         checkIsPrimaryKey(fieldName);
@@ -634,7 +638,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
      * @param value value to insert.
      * @throws IllegalArgumentException if field name doesn't exist or field isn't a binary field.
      */
-    public void setBlob(String fieldName, byte[] value) {
+    public void setBlob(String fieldName, @Nullable byte[] value) {
         proxyState.getRealm$realm().checkIfValid();
 
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
@@ -648,7 +652,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
      * @param value value to insert.
      * @throws IllegalArgumentException if field name doesn't exist or field isn't a Date field.
      */
-    public void setDate(String fieldName, Date value) {
+    public void setDate(String fieldName, @Nullable Date value) {
         proxyState.getRealm$realm().checkIfValid();
 
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
@@ -667,7 +671,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
      * @throws IllegalArgumentException if field name doesn't exist, it doesn't link to other Realm objects, the type
      * of DynamicRealmObject doesn't match or it belongs to a different Realm.
      */
-    public void setObject(String fieldName, DynamicRealmObject value) {
+    public void setObject(String fieldName, @Nullable DynamicRealmObject value) {
         proxyState.getRealm$realm().checkIfValid();
 
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
@@ -703,6 +707,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
     public void setList(String fieldName, RealmList<DynamicRealmObject> list) {
         proxyState.getRealm$realm().checkIfValid();
 
+        //noinspection ConstantConditions
         if (list == null) {
             throw new IllegalArgumentException("Null values not allowed for lists");
         }
@@ -710,6 +715,8 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
         long columnIndex = proxyState.getRow$realm().getColumnIndex(fieldName);
         LinkView links = proxyState.getRow$realm().getLinkList(columnIndex);
         Table linkTargetTable = links.getTargetTable();
+        //noinspection ConstantConditions
+        @Nonnull
         final String linkTargetTableName = linkTargetTable.getClassName();
 
         boolean typeValidated;
@@ -957,6 +964,7 @@ public class DynamicRealmObject extends RealmObject implements RealmObjectProxy 
             throw new IllegalArgumentException("Class not found: " + srcClassName);
         }
 
+        //noinspection ConstantConditions
         if (srcFieldName == null) {
             throw new IllegalArgumentException("Non-null 'srcFieldName' required.");
         }

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmInteger.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmInteger.java
@@ -15,6 +15,8 @@
  */
 package io.realm;
 
+import javax.annotation.Nullable;
+
 import io.realm.annotations.Beta;
 import io.realm.internal.ManagableObject;
 import io.realm.internal.Row;
@@ -95,9 +97,10 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
      * Unmanaged Implementation.
      */
     private static final class Unmanaged extends MutableRealmInteger {
+        @Nullable
         private Long value;
 
-        Unmanaged(Long value) {
+        Unmanaged(@Nullable Long value) {
             this.value = value;
         }
 
@@ -112,11 +115,12 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
         }
 
         @Override
-        public void set(Long newValue) {
+        public void set(@Nullable Long newValue) {
             value = newValue;
         }
 
         @Override
+        @Nullable
         public Long get() {
             return value;
         }
@@ -126,6 +130,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
             if (value == null) {
                 throw new IllegalStateException("Cannot increment a MutableRealmInteger whose value is null. Set its value first.");
             }
+            //noinspection UnnecessaryBoxing
             value = Long.valueOf(value + inc);
         }
 
@@ -140,6 +145,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
      * Managed Implementation.
      * Proxies create new subclasses for each {@code MutableRealmInteger} field.
      */
+    @SuppressWarnings("unused")
     abstract static class Managed<T extends RealmModel> extends MutableRealmInteger {
         protected abstract ProxyState<T> getProxyState();
 
@@ -164,7 +170,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
         }
 
         @Override
-        public final void set(Long value) {
+        public final void set(@Nullable Long value) {
             ProxyState proxyState = getProxyState();
             proxyState.getRealm$realm().checkIfValidAndInTransaction();
 
@@ -200,7 +206,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
             return getProxyState().getRow$realm();
         }
 
-        private void setValue(Long value, boolean isDefault) {
+        private void setValue(@Nullable Long value, boolean isDefault) {
             Row row = getRow();
             Table table = row.getTable();
             long rowIndex = row.getIndex();
@@ -226,7 +232,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
      * Creates a new, unmanaged {@code MutableRealmInteger} whose value is {@code null}.
      */
     public static MutableRealmInteger ofNull() {
-        return valueOf((Long) null);
+        return new MutableRealmInteger.Unmanaged(null);
     }
 
     /**
@@ -261,6 +267,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
      *
      * @return the value.
      */
+    @Nullable
     public abstract Long get();
 
     /**
@@ -271,7 +278,7 @@ public abstract class MutableRealmInteger implements Comparable<MutableRealmInte
      *
      * @param newValue new value.
      */
-    public abstract void set(Long newValue);
+    public abstract void set(@Nullable Long newValue);
 
     /**
      * Sets the {@code MutableRealmInteger} value.

--- a/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/MutableRealmObjectSchema.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import java.util.Locale;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Table;
 
 /**
@@ -45,6 +47,7 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
                     "Class name is too long. Limit is %1$d characters: \'%2$s\' (%3$d)",
                     Table.CLASS_NAME_MAX_LENGTH, className, className.length()));
         }
+        //noinspection ConstantConditions
         if (realm.sharedRealm.hasTable(internalTableName)) {
             throw new IllegalArgumentException("Class already exists: " + className);
         }
@@ -56,12 +59,14 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
             pkField = getPrimaryKey();
             table.setPrimaryKey(null);
         }
+        //noinspection ConstantConditions
         realm.sharedRealm.renameTable(table.getName(), internalTableName);
         if (pkField != null && !pkField.isEmpty()) {
             try {
                 table.setPrimaryKey(pkField);
             } catch (Exception e) {
                 // revert the table name back when something goes wrong
+                //noinspection ConstantConditions
                 realm.sharedRealm.renameTable(table.getName(), oldTableName);
                 throw e;
             }
@@ -70,6 +75,7 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
     }
 
     private void checkEmpty(String str) {
+        //noinspection ConstantConditions
         if (str == null || str.isEmpty()) {
             throw new IllegalArgumentException("Null or empty class names are not allowed");
         }
@@ -241,6 +247,7 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
 
     @Override
     public RealmObjectSchema transform(Function function) {
+        //noinspection ConstantConditions
         if (function != null) {
             long size = table.size();
             for (long i = 0; i < size; i++) {
@@ -255,6 +262,7 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
     private void addModifiers(String fieldName, FieldAttribute[] attributes) {
         boolean indexAdded = false;
         try {
+            //noinspection ConstantConditions
             if (attributes != null && attributes.length > 0) {
                 if (containsAttribute(attributes, FieldAttribute.INDEXED)) {
                     addIndex(fieldName);
@@ -280,6 +288,7 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
     }
 
     private boolean containsAttribute(FieldAttribute[] attributeList, FieldAttribute attribute) {
+        //noinspection ConstantConditions
         if (attributeList == null || attributeList.length == 0) {
             return false;
         }
@@ -301,5 +310,4 @@ class MutableRealmObjectSchema extends RealmObjectSchema {
             throw new IllegalArgumentException("Field already exists in '" + getClassName() + "': " + fieldName);
         }
     }
-
 }

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollection.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 
 /**
  * An {@code OrderedRealmCollection} is a collection which maintains an ordering for its elements. Every
@@ -113,7 +115,8 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      *
      * @return the first object or the provided default.
      */
-    E first(E defaultValue);
+    @Nullable
+    E first(@Nullable E defaultValue);
 
     /**
      * Gets the last object from the collection.
@@ -128,7 +131,8 @@ public interface OrderedRealmCollection<E extends RealmModel> extends List<E>, R
      *
      * @return the last object or the provided default.
      */
-    E last(E defaultValue);
+    @Nullable
+    E last(@Nullable E defaultValue);
 
     /**
      * Sorts a collection based on the provided field in ascending order.

--- a/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
+++ b/realm/realm-library/src/main/java/io/realm/OrderedRealmCollectionImpl.java
@@ -26,8 +26,8 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
             " 'OrderedRealmCollectionSnapshot'.";
 
     final BaseRealm realm;
-    final Class<E> classSpec;   // Return type
-    final String className;     // Class name used by DynamicRealmObjects
+    @Nullable final Class<E> classSpec;   // Return type
+    @Nullable final String className;     // Class name used by DynamicRealmObjects
 
     final Collection collection;
 
@@ -39,7 +39,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         this(realm, collection, null, className);
     }
 
-    private OrderedRealmCollectionImpl(BaseRealm realm, Collection collection, Class<E> clazz, String className) {
+    private OrderedRealmCollectionImpl(BaseRealm realm, Collection collection, @Nullable Class<E> clazz, @Nullable String className) {
         this.realm = realm;
         this.collection = collection;
         this.classSpec = clazz;
@@ -81,7 +81,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
      * {@code false} otherwise.
      */
     @Override
-    public boolean contains(Object object) {
+    public boolean contains(@Nullable Object object) {
         if (isLoaded()) {
             // Deleted objects can never be part of a RealmResults
             if (object instanceof RealmObjectProxy) {
@@ -125,11 +125,13 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
      * {@inheritDoc}
      */
     @Override
-    public E first(E defaultValue) {
+    @Nullable
+    public E first(@Nullable E defaultValue) {
         return firstImpl(false, defaultValue);
     }
 
-    private E firstImpl(boolean shouldThrow, E defaultValue) {
+    @Nullable
+    private E firstImpl(boolean shouldThrow, @Nullable E defaultValue) {
         UncheckedRow row = collection.firstUncheckedRow();
 
         if (row != null) {
@@ -155,12 +157,14 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
      * {@inheritDoc}
      */
     @Override
-    public E last(E defaultValue) {
+    @Nullable
+    public E last(@Nullable E defaultValue) {
         return lastImpl(false, defaultValue);
 
     }
 
-    private E lastImpl(boolean shouldThrow, E defaultValue) {
+    @Nullable
+    private E lastImpl(boolean shouldThrow, @Nullable E defaultValue) {
         UncheckedRow row = collection.lastUncheckedRow();
 
         if (row != null) {
@@ -241,6 +245,7 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
 
     // aux. method used by sort methods
     private long getColumnIndexForSort(String fieldName) {
+        //noinspection ConstantConditions
         if (fieldName == null || fieldName.isEmpty()) {
             throw new IllegalArgumentException("Non-empty field name required.");
         }
@@ -539,6 +544,8 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         if (className != null) {
             return new OrderedRealmCollectionSnapshot<E>(realm, collection, className);
         } else {
+            // 'classSpec' is non-null when 'className' is null.
+            //noinspection ConstantConditions
             return new OrderedRealmCollectionSnapshot<E>(realm, collection, classSpec);
         }
     }
@@ -560,6 +567,8 @@ abstract class OrderedRealmCollectionImpl<E extends RealmModel>
         if (className != null) {
             results = new RealmResults<E>(realm, newCollection, className);
         } else {
+            // 'classSpec' is non-null when 'className' is null.
+            //noinspection ConstantConditions
             results = new RealmResults<E>(realm, newCollection, classSpec);
         }
         results.load();

--- a/realm/realm-library/src/main/java/io/realm/ProxyState.java
+++ b/realm/realm-library/src/main/java/io/realm/ProxyState.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.ObserverPairList;
 import io.realm.internal.PendingRow;
 import io.realm.internal.Row;
@@ -35,6 +37,7 @@ public final class ProxyState<E extends RealmModel> implements PendingRow.FrontE
         private final RealmChangeListener<T> listener;
 
         RealmChangeListenerWrapper(RealmChangeListener<T> listener) {
+            //noinspection ConstantConditions
             if (listener == null) {
                 throw new IllegalArgumentException("Listener should not be null");
             }
@@ -42,7 +45,7 @@ public final class ProxyState<E extends RealmModel> implements PendingRow.FrontE
         }
 
         @Override
-        public void onChange(T object, ObjectChangeSet changes) {
+        public void onChange(T object, @Nullable ObjectChangeSet changes) {
             listener.onChange(object);
         }
 
@@ -112,6 +115,7 @@ public final class ProxyState<E extends RealmModel> implements PendingRow.FrontE
         this.acceptDefaultValue = acceptDefaultValue;
     }
 
+    @SuppressWarnings("unused")
     public List<String> getExcludeFields$realm() {
         return excludeFields;
     }

--- a/realm/realm-library/src/main/java/io/realm/Realm.java
+++ b/realm/realm-library/src/main/java/io/realm/Realm.java
@@ -210,6 +210,7 @@ public class Realm extends BaseRealm {
      */
     public static synchronized void init(Context context) {
         if (BaseRealm.applicationContext == null) {
+            //noinspection ConstantConditions
             if (context == null) {
                 throw new IllegalArgumentException("Non-null context required.");
             }
@@ -312,6 +313,7 @@ public class Realm extends BaseRealm {
      * @see RealmConfiguration for details on how to configure a Realm.
      */
     public static Realm getInstance(RealmConfiguration configuration) {
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException(NULL_CONFIG_MSG);
         }
@@ -333,6 +335,7 @@ public class Realm extends BaseRealm {
      */
     public static RealmAsyncTask getInstanceAsync(RealmConfiguration configuration,
                                                   Callback callback) {
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException(NULL_CONFIG_MSG);
         }
@@ -347,6 +350,7 @@ public class Realm extends BaseRealm {
      * @see RealmConfiguration for details on how to configure a Realm.
      */
     public static void setDefaultConfiguration(RealmConfiguration configuration) {
+        //noinspection ConstantConditions
         if (configuration == null) {
             throw new IllegalArgumentException("A non-null RealmConfiguration must be provided");
         }
@@ -533,6 +537,7 @@ public class Realm extends BaseRealm {
      * {@link RealmObjectSchema} has a {@link io.realm.annotations.PrimaryKey} defined.
      */
     public <E extends RealmModel> void createAllFromJson(Class<E> clazz, JSONArray json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null) {
             return;
         }
@@ -563,6 +568,7 @@ public class Realm extends BaseRealm {
      * @see #createAllFromJson(Class, org.json.JSONArray)
      */
     public <E extends RealmModel> void createOrUpdateAllFromJson(Class<E> clazz, JSONArray json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null) {
             return;
         }
@@ -589,6 +595,7 @@ public class Realm extends BaseRealm {
      * {@link RealmObjectSchema} has a {@link io.realm.annotations.PrimaryKey} defined.
      */
     public <E extends RealmModel> void createAllFromJson(Class<E> clazz, String json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null || json.length() == 0) {
             return;
         }
@@ -619,6 +626,7 @@ public class Realm extends BaseRealm {
      * @see #createAllFromJson(Class, String)
      */
     public <E extends RealmModel> void createOrUpdateAllFromJson(Class<E> clazz, String json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null || json.length() == 0) {
             return;
         }
@@ -651,6 +659,7 @@ public class Realm extends BaseRealm {
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public <E extends RealmModel> void createAllFromJson(Class<E> clazz, InputStream inputStream) throws IOException {
+        //noinspection ConstantConditions
         if (clazz == null || inputStream == null) {
             return;
         }
@@ -687,6 +696,7 @@ public class Realm extends BaseRealm {
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public <E extends RealmModel> void createOrUpdateAllFromJson(Class<E> clazz, InputStream in) {
+        //noinspection ConstantConditions
         if (clazz == null || in == null) {
             return;
         }
@@ -726,6 +736,7 @@ public class Realm extends BaseRealm {
      */
     @Nullable
     public <E extends RealmModel> E createObjectFromJson(Class<E> clazz, JSONObject json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null) {
             return null;
         }
@@ -754,6 +765,7 @@ public class Realm extends BaseRealm {
      * @see #createObjectFromJson(Class, org.json.JSONObject)
      */
     public <E extends RealmModel> E createOrUpdateObjectFromJson(Class<E> clazz, JSONObject json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null) {
             return null;
         }
@@ -780,6 +792,7 @@ public class Realm extends BaseRealm {
      */
     @Nullable
     public <E extends RealmModel> E createObjectFromJson(Class<E> clazz, String json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null || json.length() == 0) {
             return null;
         }
@@ -811,6 +824,7 @@ public class Realm extends BaseRealm {
      * @see #createObjectFromJson(Class, String)
      */
     public <E extends RealmModel> E createOrUpdateObjectFromJson(Class<E> clazz, String json) {
+        //noinspection ConstantConditions
         if (clazz == null || json == null || json.length() == 0) {
             return null;
         }
@@ -845,6 +859,7 @@ public class Realm extends BaseRealm {
     @Nullable
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public <E extends RealmModel> E createObjectFromJson(Class<E> clazz, InputStream inputStream) throws IOException {
+        //noinspection ConstantConditions
         if (clazz == null || inputStream == null) {
             return null;
         }
@@ -898,6 +913,7 @@ public class Realm extends BaseRealm {
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public <E extends RealmModel> E createOrUpdateObjectFromJson(Class<E> clazz, InputStream in) {
+        //noinspection ConstantConditions
         if (clazz == null || in == null) {
             return null;
         }
@@ -982,7 +998,7 @@ public class Realm extends BaseRealm {
      * @throws IllegalArgumentException if the {@code primaryKeyValue} doesn't have a value that can be converted to the
      * expected value.
      */
-    public <E extends RealmModel> E createObject(Class<E> clazz, Object primaryKeyValue) {
+    public <E extends RealmModel> E createObject(Class<E> clazz, @Nullable Object primaryKeyValue) {
         checkIfValid();
         return createObjectInternal(clazz, primaryKeyValue, true, Collections.<String>emptyList());
     }
@@ -1003,7 +1019,7 @@ public class Realm extends BaseRealm {
     // Called from proxy classes.
     <E extends RealmModel> E createObjectInternal(
             Class<E> clazz,
-            Object primaryKeyValue,
+            @Nullable Object primaryKeyValue,
             boolean acceptDefaultValue,
             List<String> excludeFields) {
         Table table = schema.getTable(clazz);
@@ -1066,6 +1082,7 @@ public class Realm extends BaseRealm {
      * @throws java.lang.IllegalArgumentException if any of the elements in the input collection is {@code null}.
      */
     public <E extends RealmModel> List<E> copyToRealm(Iterable<E> objects) {
+        //noinspection ConstantConditions
         if (objects == null) {
             return new ArrayList<>();
         }
@@ -1104,6 +1121,7 @@ public class Realm extends BaseRealm {
      */
     public void insert(Collection<? extends RealmModel> objects) {
         checkIfValidAndInTransaction();
+        //noinspection ConstantConditions
         if (objects == null) {
             throw new IllegalArgumentException("Null objects cannot be inserted into Realm.");
         }
@@ -1140,6 +1158,7 @@ public class Realm extends BaseRealm {
      */
     public void insert(RealmModel object) {
         checkIfValidAndInTransaction();
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException("Null object cannot be inserted into Realm.");
         }
@@ -1175,6 +1194,7 @@ public class Realm extends BaseRealm {
      */
     public void insertOrUpdate(Collection<? extends RealmModel> objects) {
         checkIfValidAndInTransaction();
+        //noinspection ConstantConditions
         if (objects == null) {
             throw new IllegalArgumentException("Null objects cannot be inserted into Realm.");
         }
@@ -1210,6 +1230,7 @@ public class Realm extends BaseRealm {
      */
     public void insertOrUpdate(RealmModel object) {
         checkIfValidAndInTransaction();
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException("Null object cannot be inserted into Realm.");
         }
@@ -1231,6 +1252,7 @@ public class Realm extends BaseRealm {
      * @see #copyToRealm(Iterable)
      */
     public <E extends RealmModel> List<E> copyToRealmOrUpdate(Iterable<E> objects) {
+        //noinspection ConstantConditions
         if (objects == null) {
             return new ArrayList<>(0);
         }
@@ -1289,6 +1311,7 @@ public class Realm extends BaseRealm {
      */
     public <E extends RealmModel> List<E> copyFromRealm(Iterable<E> realmObjects, int maxDepth) {
         checkMaxDepth(maxDepth);
+        //noinspection ConstantConditions
         if (realmObjects == null) {
             return new ArrayList<>(0);
         }
@@ -1415,6 +1438,7 @@ public class Realm extends BaseRealm {
      * @throws RealmMigrationNeededException if the latest version contains incompatible schema changes.
      */
     public void executeTransaction(Transaction transaction) {
+        //noinspection ConstantConditions
         if (transaction == null) {
             throw new IllegalArgumentException("Transaction should not be null");
         }
@@ -1455,6 +1479,7 @@ public class Realm extends BaseRealm {
      * another thread.
      */
     public RealmAsyncTask executeTransactionAsync(final Transaction transaction, final Realm.Transaction.OnSuccess onSuccess) {
+        //noinspection ConstantConditions
         if (onSuccess == null) {
             throw new IllegalArgumentException("onSuccess callback can't be null");
         }
@@ -1472,6 +1497,7 @@ public class Realm extends BaseRealm {
      * another thread.
      */
     public RealmAsyncTask executeTransactionAsync(final Transaction transaction, final Realm.Transaction.OnError onError) {
+        //noinspection ConstantConditions
         if (onError == null) {
             throw new IllegalArgumentException("onError callback can't be null");
         }
@@ -1490,10 +1516,11 @@ public class Realm extends BaseRealm {
      * another thread.
      */
     public RealmAsyncTask executeTransactionAsync(final Transaction transaction,
-            final Realm.Transaction.OnSuccess onSuccess,
-            final Realm.Transaction.OnError onError) {
+            @Nullable final Realm.Transaction.OnSuccess onSuccess,
+            @Nullable final Realm.Transaction.OnError onError) {
         checkIfValid();
 
+        //noinspection ConstantConditions
         if (transaction == null) {
             throw new IllegalArgumentException("Transaction should not be null");
         }
@@ -1626,6 +1653,7 @@ public class Realm extends BaseRealm {
     }
 
     private <E extends RealmModel> void checkNotNullObject(E object) {
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException("Null objects cannot be copied into Realm.");
         }
@@ -1644,6 +1672,7 @@ public class Realm extends BaseRealm {
     }
 
     private <E extends RealmModel> void checkValidObjectForDetach(E realmObject) {
+        //noinspection ConstantConditions
         if (realmObject == null) {
             throw new IllegalArgumentException("Null objects cannot be copied from Realm.");
         }
@@ -1690,7 +1719,7 @@ public class Realm extends BaseRealm {
      * configuration.
      * @throws FileNotFoundException if the Realm file doesn't exist.
      */
-    public static void migrateRealm(RealmConfiguration configuration, RealmMigration migration)
+    public static void migrateRealm(RealmConfiguration configuration, @Nullable RealmMigration migration)
             throws FileNotFoundException {
         BaseRealm.migrateRealm(configuration, migration, new MigrationCallback() {
             @Override

--- a/realm/realm-library/src/main/java/io/realm/RealmCache.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCache.java
@@ -144,6 +144,8 @@ final class RealmCache {
                         if (instanceToReturn != null) {
                             callback.onSuccess(instanceToReturn);
                         } else {
+                            // throwable is non-null
+                            //noinspection ConstantConditions
                             callback.onError(throwable);
                         }
                     }
@@ -258,6 +260,7 @@ final class RealmCache {
             RealmConfiguration configuration, BaseRealm.InstanceCallback<T> callback, Class<T> realmClass) {
         Capabilities capabilities = new AndroidCapabilities();
         capabilities.checkCanDeliverNotification(ASYNC_NOT_ALLOWED_MSG);
+        //noinspection ConstantConditions
         if (callback == null) {
             throw new IllegalArgumentException(ASYNC_CALLBACK_NULL_MSG);
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmChangeListener.java
@@ -16,6 +16,7 @@
 
 package io.realm;
 
+
 /**
  * RealmChangeListener can be registered with a {@link Realm}, {@link RealmResults} or {@link RealmObject}
  * to receive a notification about updates.
@@ -43,5 +44,4 @@ public interface RealmChangeListener<T> {
      * Called when a transaction is committed.
      */
     void onChange(T t);
-
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmCollection.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmCollection.java
@@ -183,5 +183,5 @@ public interface RealmCollection<E extends RealmModel> extends Collection<E>, Ma
      * support {@code null} elements.
      */
     @Override
-    boolean contains(Object object);
+    boolean contains(@Nullable Object object);
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmConfiguration.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import io.realm.annotations.RealmModule;
 import io.realm.exceptions.RealmException;
 import io.realm.exceptions.RealmFileException;
@@ -105,17 +107,17 @@ public class RealmConfiguration {
     protected RealmConfiguration(File realmDirectory,
             String realmFileName,
             String canonicalPath,
-            String assetFilePath,
-            byte[] key,
+            @Nullable String assetFilePath,
+            @Nullable byte[] key,
             long schemaVersion,
-            RealmMigration migration,
+            @Nullable RealmMigration migration,
             boolean deleteRealmIfMigrationNeeded,
             SharedRealm.Durability durability,
             RealmProxyMediator schemaMediator,
-            RxObservableFactory rxObservableFactory,
-            Realm.Transaction initialDataTransaction,
+            @Nullable RxObservableFactory rxObservableFactory,
+            @Nullable Realm.Transaction initialDataTransaction,
             boolean readOnly,
-            CompactOnLaunchCallback compactOnLaunch) {
+            @Nullable CompactOnLaunchCallback compactOnLaunch) {
         this.realmDirectory = realmDirectory;
         this.realmFileName = realmFileName;
         this.canonicalPath = canonicalPath;
@@ -453,6 +455,7 @@ public class RealmConfiguration {
         }
 
         Builder(Context context) {
+            //noinspection ConstantConditions
             if (context == null) {
                 throw new IllegalStateException("Call `Realm.init(Context)` before creating a RealmConfiguration");
             }
@@ -480,6 +483,7 @@ public class RealmConfiguration {
          * Sets the filename for the Realm file.
          */
         public Builder name(String filename) {
+            //noinspection ConstantConditions
             if (filename == null || filename.isEmpty()) {
                 throw new IllegalArgumentException("A non-empty filename must be provided");
             }
@@ -496,6 +500,7 @@ public class RealmConfiguration {
          * @throws IllegalArgumentException if {@code directory} is null, not writable or a file.
          */
         public Builder directory(File directory) {
+            //noinspection ConstantConditions
             if (directory == null) {
                 throw new IllegalArgumentException("Non-null 'dir' required.");
             }
@@ -517,6 +522,7 @@ public class RealmConfiguration {
          * Sets the {@value io.realm.RealmConfiguration#KEY_LENGTH} bytes key used to encrypt and decrypt the Realm file.
          */
         public Builder encryptionKey(byte[] key) {
+            //noinspection ConstantConditions
             if (key == null) {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
@@ -552,6 +558,7 @@ public class RealmConfiguration {
          * will be thrown.
          */
         public Builder migration(RealmMigration migration) {
+            //noinspection ConstantConditions
             if (migration == null) {
                 throw new IllegalArgumentException("A non-null migration must be provided");
             }
@@ -617,6 +624,7 @@ public class RealmConfiguration {
         public Builder modules(Object baseModule, Object... additionalModules) {
             modules.clear();
             addModule(baseModule);
+            //noinspection ConstantConditions
             if (additionalModules != null) {
                 for (int i = 0; i < additionalModules.length; i++) {
                     Object module = additionalModules[i];
@@ -709,6 +717,7 @@ public class RealmConfiguration {
          *                        the total file size (data + free space) and the bytes used by data in the file.
          */
         public Builder compactOnLaunch(CompactOnLaunchCallback compactOnLaunch) {
+            //noinspection ConstantConditions
             if (compactOnLaunch == null) {
                 throw new IllegalArgumentException("A non-null compactOnLaunch must be provided");
             }
@@ -717,6 +726,7 @@ public class RealmConfiguration {
         }
 
         private void addModule(Object module) {
+            //noinspection ConstantConditions
             if (module != null) {
                 checkModule(module);
                 modules.add(module);
@@ -730,12 +740,14 @@ public class RealmConfiguration {
          */
         @SafeVarargs
         final Builder schema(Class<? extends RealmModel> firstClass, Class<? extends RealmModel>... additionalClasses) {
+            //noinspection ConstantConditions
             if (firstClass == null) {
                 throw new IllegalArgumentException("A non-null class must be provided");
             }
             modules.clear();
             modules.add(DEFAULT_MODULE_MEDIATOR);
             debugSchema.add(firstClass);
+            //noinspection ConstantConditions
             if (additionalClasses != null) {
                 Collections.addAll(debugSchema, additionalClasses);
             }

--- a/realm/realm-library/src/main/java/io/realm/RealmFieldType.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmFieldType.java
@@ -18,6 +18,8 @@ package io.realm;
 
 import java.nio.ByteBuffer;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Keep;
 
 
@@ -87,6 +89,7 @@ public enum RealmFieldType {
             case 4:
                 return (obj instanceof byte[] || obj instanceof ByteBuffer);
             case 5:
+                //noinspection ConstantConditions
                 return (obj == null || obj instanceof Object[][]);
             case 7:
                 return (obj instanceof java.util.Date); // The unused DateTime.

--- a/realm/realm-library/src/main/java/io/realm/RealmList.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmList.java
@@ -28,6 +28,9 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import io.realm.internal.InvalidRow;
 import io.realm.internal.LinkView;
 import io.realm.internal.RealmObjectProxy;
@@ -59,7 +62,9 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
     public static final String REMOVE_OUTSIDE_TRANSACTION_ERROR = "Objects can only be removed from inside a write transaction";
 
     private final io.realm.internal.Collection collection;
+    @Nullable
     protected Class<E> clazz;
+    @Nullable
     protected String className;
     final LinkView view;
     protected BaseRealm realm;
@@ -88,6 +93,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * @param objects initial objects in the list.
      */
     public RealmList(E... objects) {
+        //noinspection ConstantConditions
         if (objects == null) {
             throw new IllegalArgumentException("The objects argument cannot be null");
         }
@@ -247,6 +253,8 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
             RealmObjectProxy proxy = (RealmObjectProxy) object;
 
             if (proxy instanceof DynamicRealmObject) {
+                //noinspection ConstantConditions
+                @Nonnull
                 String listClassName = view.getTargetTable().getClassName();
                 if (proxy.realmGet$proxyState().getRealm$realm() == realm) {
                     String objectClassName = ((DynamicRealmObject) object).getType();
@@ -470,11 +478,13 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
-    public E first(E defaultValue) {
+    @Nullable
+    public E first(@Nullable E defaultValue) {
         return firstImpl(false, defaultValue);
     }
 
-    private E firstImpl(boolean shouldThrow, E defaultValue) {
+    @Nullable
+    private E firstImpl(boolean shouldThrow, @Nullable E defaultValue) {
         if (isManaged()) {
             checkValidView();
             if (!view.isEmpty()) {
@@ -503,11 +513,13 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
-    public E last(E defaultValue) {
+    @Nullable
+    public E last(@Nullable E defaultValue) {
         return lastImpl(false, defaultValue);
     }
 
-    private E lastImpl(boolean shouldThrow, E defaultValue) {
+    @Nullable
+    private E lastImpl(boolean shouldThrow, @Nullable E defaultValue) {
         if (isManaged()) {
             checkValidView();
             if (!view.isEmpty()) {
@@ -616,6 +628,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public Number min(String fieldName) {
         if (isManaged()) {
             return this.where().min(fieldName);
@@ -628,6 +641,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public Number max(String fieldName) {
         if (isManaged()) {
             return this.where().max(fieldName);
@@ -664,6 +678,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public Date maxDate(String fieldName) {
         if (isManaged()) {
             return this.where().maximumDate(fieldName);
@@ -676,6 +691,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public Date minDate(String fieldName) {
         if (isManaged()) {
             return this.where().minimumDate(fieldName);
@@ -730,7 +746,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * @return {@code true} if this list contains the specified element otherwise {@code false}.
      */
     @Override
-    public boolean contains(Object object) {
+    public boolean contains(@Nullable Object object) {
         if (isManaged()) {
             realm.checkIfValid();
 
@@ -757,6 +773,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nonnull
     public Iterator<E> iterator() {
         if (isManaged()) {
             return new RealmItr();
@@ -769,6 +786,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nonnull
     public ListIterator<E> listIterator() {
         return listIterator(0);
     }
@@ -777,6 +795,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
      * {@inheritDoc}
      */
     @Override
+    @Nonnull
     public ListIterator<E> listIterator(int location) {
         if (isManaged()) {
             return new RealmListItr(location);
@@ -786,6 +805,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
     }
 
     private void checkValidObject(E object) {
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException(NULL_OBJECTS_NOT_ALLOWED_MESSAGE);
         }
@@ -820,6 +840,8 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
                     new io.realm.internal.Collection(realm.sharedRealm, view, null),
                     className);
         } else {
+            // 'clazz' is non-null when 'dynamicClassName' is null.
+            //noinspection ConstantConditions
             return new OrderedRealmCollectionSnapshot<>(
                     realm,
                     new io.realm.internal.Collection(realm.sharedRealm, view, null),
@@ -830,7 +852,13 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append(isManaged() ? clazz.getSimpleName() : getClass().getSimpleName());
+        if (isManaged()) {
+            // 'clazz' is non-null when 'dynamicClassName' is null.
+            //noinspection ConstantConditions
+            sb.append(className != null ? className : realm.getSchema().getSchemaForClass(clazz).getClassName());
+        } else {
+            sb.append(getClass().getSimpleName());
+        }
         sb.append("@[");
         if (isManaged() && !isAttached()) {
             sb.append("invalid");
@@ -849,7 +877,6 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
         sb.append("]");
         return sb.toString();
     }
-
 
     /**
      * Returns an Rx Observable that monitors changes to this RealmList. It will emit the current RealmList when
@@ -891,7 +918,7 @@ public class RealmList<E extends RealmModel> extends AbstractList<E> implements 
         }
     }
 
-    private void checkForAddRemoveListener(Object listener, boolean checkListener) {
+    private void checkForAddRemoveListener(@Nullable Object listener, boolean checkListener) {
         if (checkListener && listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmObject.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObject.java
@@ -433,9 +433,11 @@ public abstract class RealmObject implements RealmModel, ManagableObject {
      * @throws IllegalStateException if you try to add a listener inside a transaction.
      */
     public static <E extends RealmModel> void addChangeListener(E object, RealmObjectChangeListener<E> listener) {
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException("Object should not be null");
         }
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }
@@ -523,9 +525,11 @@ public abstract class RealmObject implements RealmModel, ManagableObject {
      * @throws IllegalStateException if you try to remove a listener from a non-Looper Thread.
      */
     public static <E extends RealmModel> void removeChangeListener(E object, RealmObjectChangeListener listener) {
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException("Object should not be null");
         }
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectChangeListener.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectChangeListener.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import javax.annotation.Nullable;
+
 import io.realm.annotations.LinkingObjects;
 
 /**
@@ -54,5 +56,5 @@ public interface RealmObjectChangeListener<T extends RealmModel> {
      * @param t the {@code RealmObject} this listener is registered to.
      * @param changeSet the detailed information about the changes.
      */
-    void onChange(T t, ObjectChangeSet changeSet);
+    void onChange(T t, @Nullable ObjectChangeSet changeSet);
 }

--- a/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmObjectSchema.java
@@ -363,6 +363,7 @@ public abstract class RealmObjectSchema {
      * Runs a transformation function on each RealmObject instance of the current class. The object will be represented
      * as a {@link DynamicRealmObject}.
      *
+     * @param function transformation function.
      * @return this schema.
      * @throws UnsupportedOperationException if this {@link RealmObjectSchema} is immutable.
      */
@@ -371,6 +372,7 @@ public abstract class RealmObjectSchema {
     /**
      * Returns the type used by the underlying storage engine to represent this field.
      *
+     * @param fieldName name of the target field.
      * @return the underlying type used by Realm to represent this field.
      */
     public RealmFieldType getFieldType(String fieldName) {
@@ -445,6 +447,7 @@ public abstract class RealmObjectSchema {
     }
 
     void checkLegalName(String fieldName) {
+        //noinspection ConstantConditions
         if (fieldName == null || fieldName.isEmpty()) {
             throw new IllegalArgumentException("Field name can not be null or empty");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmQuery.java
@@ -99,6 +99,7 @@ public class RealmQuery<E extends RealmModel> {
      */
     @SuppressWarnings("unchecked")
     public static <E extends RealmModel> RealmQuery<E> createQueryFromResult(RealmResults<E> queryResults) {
+        //noinspection ConstantConditions
         return (queryResults.classSpec == null)
                 ? new RealmQuery(queryResults, queryResults.className)
                 : new RealmQuery<>(queryResults, queryResults.classSpec);
@@ -113,6 +114,7 @@ public class RealmQuery<E extends RealmModel> {
      */
     @SuppressWarnings("unchecked")
     public static <E extends RealmModel> RealmQuery<E> createQueryFromList(RealmList<E> list) {
+        //noinspection ConstantConditions
         return (list.clazz == null)
                 ? new RealmQuery(list.realm, list.view, list.className)
                 : new RealmQuery(list.realm, list.view, list.clazz);
@@ -235,7 +237,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, String value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable String value) {
         return this.equalTo(fieldName, value, Case.SENSITIVE);
     }
 
@@ -248,13 +250,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, String value, Case casing) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable String value, Case casing) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value, casing);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, String value, Case casing) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable String value, Case casing) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
         this.query.equalTo(fd.getColumnIndices(), fd.getNativeTablePointers(), value, casing);
         return this;
@@ -268,13 +270,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Byte value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Byte value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Byte value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Byte value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -292,7 +294,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, byte[] value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable byte[] value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.BINARY);
@@ -312,13 +314,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Short value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Short value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Short value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Short value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -336,13 +338,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Integer value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Integer value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Integer value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Integer value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -360,13 +362,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Long value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Long value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Long value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Long value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -384,13 +386,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Double value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Double value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Double value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Double value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -408,13 +410,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return The query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Float value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Float value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Float value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Float value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -432,13 +434,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Boolean value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Boolean value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Boolean value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Boolean value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.BOOLEAN);
         if (value == null) {
             this.query.isNull(fd.getColumnIndices(), fd.getNativeTablePointers());
@@ -456,13 +458,13 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> equalTo(String fieldName, Date value) {
+    public RealmQuery<E> equalTo(String fieldName, @Nullable Date value) {
         realm.checkIfValid();
 
         return equalToWithoutThreadValidation(fieldName, value);
     }
 
-    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, Date value) {
+    private RealmQuery<E> equalToWithoutThreadValidation(String fieldName, @Nullable Date value) {
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
         this.query.equalTo(fd.getColumnIndices(), fd.getNativeTablePointers(), value);
         return this;
@@ -494,6 +496,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, String[] values, Case casing) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -516,6 +519,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Byte[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -538,6 +542,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Short[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -560,6 +565,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Integer[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -582,6 +588,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Long[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -604,6 +611,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Double[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -626,6 +634,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Float[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -648,6 +657,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Boolean[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -670,6 +680,7 @@ public class RealmQuery<E extends RealmModel> {
     public RealmQuery<E> in(String fieldName, Date[] values) {
         realm.checkIfValid();
 
+        //noinspection ConstantConditions
         if (values == null || values.length == 0) {
             throw new IllegalArgumentException(EMPTY_VALUES);
         }
@@ -688,7 +699,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, String value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable String value) {
         return this.notEqualTo(fieldName, value, Case.SENSITIVE);
     }
 
@@ -701,7 +712,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, String value, Case casing) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable String value, Case casing) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.STRING);
@@ -720,7 +731,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Byte value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Byte value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
@@ -740,7 +751,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, byte[] value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable byte[] value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.BINARY);
@@ -760,7 +771,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Short value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Short value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
@@ -780,7 +791,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Integer value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Integer value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
@@ -800,7 +811,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Long value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Long value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.INTEGER);
@@ -820,7 +831,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Double value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Double value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.DOUBLE);
@@ -840,7 +851,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Float value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Float value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.FLOAT);
@@ -860,7 +871,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Boolean value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Boolean value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.BOOLEAN);
@@ -880,7 +891,7 @@ public class RealmQuery<E extends RealmModel> {
      * @return the query object.
      * @throws java.lang.IllegalArgumentException if one or more arguments do not match class or field type.
      */
-    public RealmQuery<E> notEqualTo(String fieldName, Date value) {
+    public RealmQuery<E> notEqualTo(String fieldName, @Nullable Date value) {
         realm.checkIfValid();
 
         FieldDescriptor fd = schema.getColumnIndices(fieldName, RealmFieldType.DATE);
@@ -1970,8 +1981,8 @@ public class RealmQuery<E extends RealmModel> {
     }
 
     private RealmResults<E> createRealmResults(TableQuery query,
-            SortDescriptor sortDescriptor,
-            SortDescriptor distinctDescriptor,
+            @Nullable SortDescriptor sortDescriptor,
+            @Nullable SortDescriptor distinctDescriptor,
             boolean loadResults) {
         RealmResults<E> results;
         Collection collection = new Collection(realm.sharedRealm, query, sortDescriptor, distinctDescriptor);

--- a/realm/realm-library/src/main/java/io/realm/RealmResults.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmResults.java
@@ -19,7 +19,9 @@ package io.realm;
 
 import android.annotation.SuppressLint;
 import android.os.Looper;
-import android.util.Log;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.realm.internal.CheckedRow;
 import io.realm.internal.Collection;
@@ -72,10 +74,12 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
 
     // Abandon typing information, all ye who enter here
     static RealmResults<DynamicRealmObject> createDynamicBacklinkResults(DynamicRealm realm, CheckedRow row, Table srcTable, String srcFieldName) {
+        final String srcClassName = Table.getClassNameForTable(srcTable.getName());
+        //noinspection ConstantConditions
         return new RealmResults<>(
                 realm,
                 Collection.createBacklinksCollection(realm.sharedRealm, row, srcTable, srcFieldName),
-                Table.getClassNameForTable(srcTable.getName()));
+                srcClassName);
     }
 
     RealmResults(BaseRealm realm, Collection collection, Class<E> clazz) {
@@ -209,7 +213,7 @@ public class RealmResults<E extends RealmModel> extends OrderedRealmCollectionIm
         collection.addListener(this, listener);
     }
 
-    private void checkForAddRemoveListener(Object listener, boolean checkListener) {
+    private void checkForAddRemoveListener(@Nullable Object listener, boolean checkListener) {
         if (checkListener && listener == null) {
             throw new IllegalArgumentException("Listener should not be null");
         }

--- a/realm/realm-library/src/main/java/io/realm/RealmSchema.java
+++ b/realm/realm-library/src/main/java/io/realm/RealmSchema.java
@@ -139,6 +139,7 @@ public abstract class RealmSchema {
     }
 
     void checkNotEmpty(String str, String error) {
+        //noinspection ConstantConditions
         if (str == null || str.isEmpty()) {
             throw new IllegalArgumentException(error);
         }

--- a/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/RealmMigrationNeededException.java
@@ -18,6 +18,8 @@ package io.realm.exceptions;
 
 import java.io.File;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Keep;
 
 
@@ -31,7 +33,7 @@ public final class RealmMigrationNeededException extends RuntimeException {
         this.canonicalRealmPath = canonicalRealmPath;
     }
 
-    public RealmMigrationNeededException(String canonicalRealmPath, String detailMessage, Throwable throwable) {
+    public RealmMigrationNeededException(String canonicalRealmPath, String detailMessage, @Nullable Throwable throwable) {
         super(detailMessage, throwable);
         this.canonicalRealmPath = canonicalRealmPath;
     }

--- a/realm/realm-library/src/main/java/io/realm/exceptions/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/exceptions/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.exceptions;

--- a/realm/realm-library/src/main/java/io/realm/internal/Capabilities.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Capabilities.java
@@ -16,6 +16,9 @@
 
 package io.realm.internal;
 
+import javax.annotation.Nullable;
+
+
 /**
  * To describe what the Realm instance can do associated with the thread it is created on.
  * The capabilities are determined when the Realm gets created. This interface could be called from another thread which
@@ -34,7 +37,7 @@ public interface Capabilities {
      *
      * @param exceptionMessage message which is contained in the exception.
      */
-    void checkCanDeliverNotification(String exceptionMessage);
+    void checkCanDeliverNotification(@Nullable String exceptionMessage);
 
     /**
      * Multiple threads might be able to deliver notifications, but the Main thread in GUI applications often have

--- a/realm/realm-library/src/main/java/io/realm/internal/Collection.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Collection.java
@@ -20,6 +20,8 @@ import java.util.ConcurrentModificationException;
 import java.util.Date;
 import java.util.NoSuchElementException;
 
+import javax.annotation.Nullable;
+
 import io.realm.OrderedCollectionChangeSet;
 import io.realm.OrderedRealmCollectionChangeListener;
 import io.realm.RealmChangeListener;
@@ -339,7 +341,7 @@ public class Collection implements NativeObject {
     }
 
     public Collection(SharedRealm sharedRealm, TableQuery query,
-            SortDescriptor sortDescriptor, SortDescriptor distinctDescriptor) {
+            @Nullable SortDescriptor sortDescriptor, @Nullable SortDescriptor distinctDescriptor) {
         query.validateQuery();
 
         this.nativePtr = nativeCreateResults(sharedRealm.getNativePtr(), query.getNativePtr(),
@@ -353,7 +355,7 @@ public class Collection implements NativeObject {
         this.loaded = false;
     }
 
-    public Collection(SharedRealm sharedRealm, TableQuery query, SortDescriptor sortDescriptor) {
+    public Collection(SharedRealm sharedRealm, TableQuery query, @Nullable SortDescriptor sortDescriptor) {
         this(sharedRealm, query, sortDescriptor, null);
     }
 
@@ -361,7 +363,7 @@ public class Collection implements NativeObject {
         this(sharedRealm, query, null, null);
     }
 
-    public Collection(SharedRealm sharedRealm, LinkView linkView, SortDescriptor sortDescriptor) {
+    public Collection(SharedRealm sharedRealm, LinkView linkView, @Nullable SortDescriptor sortDescriptor) {
         this.nativePtr = nativeCreateResultsFromLinkView(sharedRealm.getNativePtr(), linkView.getNativePtr(),
                 sortDescriptor);
 
@@ -561,10 +563,10 @@ public class Collection implements NativeObject {
     private static native long nativeGetFinalizerPtr();
 
     private static native long nativeCreateResults(long sharedRealmNativePtr, long queryNativePtr,
-            SortDescriptor sortDesc, SortDescriptor distinctDesc);
+            @Nullable SortDescriptor sortDesc, @Nullable SortDescriptor distinctDesc);
 
     private static native long nativeCreateResultsFromLinkView(long sharedRealmNativePtr, long linkViewPtr,
-            SortDescriptor sortDesc);
+            @Nullable SortDescriptor sortDesc);
 
     private static native long nativeCreateSnapshot(long nativePtr);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/CollectionChangeSet.java
@@ -16,6 +16,8 @@
 
 package io.realm.internal;
 
+import javax.annotation.Nullable;
+
 import io.realm.OrderedCollectionChangeSet;
 
 
@@ -110,6 +112,7 @@ public class CollectionChangeSet implements OrderedCollectionChangeSet, NativeOb
 
     // Convert long array returned by the nativeGetXxxRanges() to Range array.
     private Range[] longArrayToRangeArray(int[] longArray) {
+        //noinspection ConstantConditions
         if (longArray == null) {
             // Returns a size 0 array so we know JNI gets called.
             return new Range[0];

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnIndices.java
@@ -151,7 +151,7 @@ public final class ColumnIndices {
      * the same the corresponding data in the passed instance or IllegalStateException will be thrown.
      * It is allowable for the passed ColumnIndices to contain information this instance does not.
      * <p>
-     * NOTE: copying does not change this instance's mutablity state.
+     * NOTE: copying does not change this instance's mutability state.
      *
      * @param src the instance to copy.
      * @throws UnsupportedOperationException if this instance is immutable.

--- a/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ColumnInfo.java
@@ -102,7 +102,7 @@ public abstract class ColumnInfo {
      * @param src the instance to copy
      * @param mutable false to make this instance effectively final
      */
-    protected ColumnInfo(ColumnInfo src, boolean mutable) {
+    protected ColumnInfo(@Nullable ColumnInfo src, boolean mutable) {
         this((src == null) ? 0 : src.indicesMap.size(), mutable);
         // ColumnDetails are immutable and may be re-used.
         if (src != null) {

--- a/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObjectServerFacade.java
@@ -100,9 +100,10 @@ public class ObjectServerFacade {
     /**
      * Block until all latest changes have been downloaded from the server.
      *
-     * @throws {@code DownloadingRealmInterruptedException}  if the thread was interrupted while blocked waiting for
+     * @throws {@code DownloadingRealmInterruptedException} if the thread was interrupted while blocked waiting for
      * this to complete.
      */
+    @SuppressWarnings("JavaDoc")
     public void downloadRemoteChanges(RealmConfiguration config) {
         // Do nothing
     }

--- a/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/ObserverPairList.java
@@ -71,6 +71,7 @@ public class ObserverPairList<T extends ObserverPairList.ObserverPair> {
 
             int result = 17;
             result = 31 * result + ((observer != null) ? observer.hashCode() : 0);
+            //noinspection ConstantConditions
             result = 31 * result + ((listener != null) ? listener.hashCode() : 0);
             return result;
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/OsObject.java
@@ -16,6 +16,8 @@
 
 package io.realm.internal;
 
+import javax.annotation.Nullable;
+
 import io.realm.ObjectChangeSet;
 import io.realm.RealmFieldType;
 import io.realm.RealmModel;
@@ -65,7 +67,7 @@ public class OsObject implements NativeObject {
             super(observer, listener);
         }
 
-        public void onChange(T observer, ObjectChangeSet changeSet) {
+        public void onChange(T observer, @Nullable ObjectChangeSet changeSet) {
             listener.onChange(observer, changeSet);
         }
     }
@@ -185,7 +187,7 @@ public class OsObject implements NativeObject {
      * @param table the table where the object is created. This table must be atached to {@link SharedRealm}.
      * @return a newly created {@code UncheckedRow}.
      */
-    public static UncheckedRow createWithPrimaryKey(Table table, Object primaryKeyValue) {
+    public static UncheckedRow createWithPrimaryKey(Table table, @Nullable Object primaryKeyValue) {
         long primaryKeyColumnIndex = getAndVerifyPrimaryKeyColumnIndex(table);
         RealmFieldType type = table.getColumnType(primaryKeyColumnIndex);
         final SharedRealm sharedRealm = table.getSharedRealm();
@@ -269,7 +271,7 @@ public class OsObject implements NativeObject {
     // Return a pointer to newly created Row. We may need to return a OsObject pointer in the future.
     private static native long nativeCreateNewObjectWithStringPrimaryKey(long sharedRealmPtr,
                                                                          long tablePtr, long pk_column_index,
-                                                                         String primaryKeyValue);
+                                                                         @Nullable String primaryKeyValue);
 
     // Return a index of newly created Row.
     private static native long nativeCreateRowWithStringPrimaryKey(long sharedRealmPtr,

--- a/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/PendingRow.java
@@ -3,6 +3,8 @@ package io.realm.internal;
 import java.lang.ref.WeakReference;
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmChangeListener;
 import io.realm.RealmFieldType;
 
@@ -35,7 +37,7 @@ public class PendingRow implements Row {
     private WeakReference<FrontEnd> frontEndRef;
     private boolean returnCheckedRow;
 
-    public PendingRow(SharedRealm sharedRealm, TableQuery query, SortDescriptor sortDescriptor,
+    public PendingRow(SharedRealm sharedRealm, TableQuery query, @Nullable SortDescriptor sortDescriptor,
             final boolean returnCheckedRow) {
         this.sharedRealm = sharedRealm;
         pendingCollection = new Collection(sharedRealm, query, sortDescriptor, null);

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmNotifier.java
@@ -20,6 +20,8 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmChangeListener;
 
 
@@ -53,6 +55,7 @@ public abstract class RealmNotifier implements Closeable {
         }
 
         private void onChange(T observer) {
+            //noinspection ConstantConditions
             if (observer != null) {
                 listener.onChange(observer);
             }
@@ -71,7 +74,7 @@ public abstract class RealmNotifier implements Closeable {
                 }
             };
 
-    protected RealmNotifier(SharedRealm sharedRealm) {
+    protected RealmNotifier(@Nullable SharedRealm sharedRealm) {
         this.sharedRealm = sharedRealm;
     }
 

--- a/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/RealmProxyMediator.java
@@ -223,6 +223,7 @@ public abstract class RealmProxyMediator {
     }
 
     protected static void checkClass(Class<? extends RealmModel> clazz) {
+        //noinspection ConstantConditions
         if (clazz == null) {
             throw new NullPointerException("A class extending RealmObject must be provided");
         }

--- a/realm/realm-library/src/main/java/io/realm/internal/Row.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Row.java
@@ -18,6 +18,8 @@ package io.realm.internal;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmFieldType;
 
 
@@ -91,9 +93,9 @@ public interface Row {
 
     void setDate(long columnIndex, Date date);
 
-    void setString(long columnIndex, String value);
+    void setString(long columnIndex, @Nullable String value);
 
-    void setBinaryByteArray(long columnIndex, byte[] data);
+    void setBinaryByteArray(long columnIndex, @Nullable byte[] data);
 
     void setLink(long columnIndex, long value);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SharedRealm.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.annotation.Nullable;
+
 import io.realm.CompactOnLaunchCallback;
 import io.realm.RealmConfiguration;
 import io.realm.internal.android.AndroidCapabilities;
@@ -179,7 +181,7 @@ public final class SharedRealm implements Closeable, NativeObject {
 
     private SharedRealm(long nativeConfigPtr,
             RealmConfiguration configuration,
-            SchemaVersionListener schemaVersionListener) {
+            @Nullable SchemaVersionListener schemaVersionListener) {
         Capabilities capabilities = new AndroidCapabilities();
         RealmNotifier realmNotifier = new AndroidRealmNotifier(this, capabilities);
 
@@ -203,7 +205,7 @@ public final class SharedRealm implements Closeable, NativeObject {
     }
 
 
-    public static SharedRealm getInstance(RealmConfiguration config, SchemaVersionListener schemaVersionListener,
+    public static SharedRealm getInstance(RealmConfiguration config, @Nullable SchemaVersionListener schemaVersionListener,
             boolean autoChangeNotifications) {
         Object[] syncUserConf = ObjectServerFacade.getSyncFacadeIfPossible().getUserAndServerUrl(config);
         String syncUserIdentifier = (String) syncUserConf[0];
@@ -348,7 +350,7 @@ public final class SharedRealm implements Closeable, NativeObject {
         return nativeIsClosed(nativePtr);
     }
 
-    public void writeCopy(File file, byte[] key) {
+    public void writeCopy(File file, @Nullable byte[] key) {
         if (file.isFile() && file.exists()) {
             throw new IllegalArgumentException("The destination file must not exist");
         }
@@ -559,7 +561,7 @@ public final class SharedRealm implements Closeable, NativeObject {
 
     private static native long nativeSize(long nativeSharedRealmPtr);
 
-    private static native void nativeWriteCopy(long nativeSharedRealmPtr, String path, byte[] key);
+    private static native void nativeWriteCopy(long nativeSharedRealmPtr, String path, @Nullable byte[] key);
 
     private static native boolean nativeWaitForChange(long nativeSharedRealmPtr);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/SortDescriptor.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmFieldType;
 import io.realm.Sort;
 import io.realm.internal.fields.FieldDescriptor;
@@ -53,6 +55,7 @@ public class SortDescriptor {
     }
 
     public static SortDescriptor getInstanceForSort(FieldDescriptor.SchemaProxy proxy, Table table, String[] fieldDescriptions, Sort[] sortOrders) {
+        //noinspection ConstantConditions
         if (sortOrders == null || sortOrders.length == 0) {
             throw new IllegalArgumentException("You must provide at least one sort order.");
         }
@@ -74,11 +77,12 @@ public class SortDescriptor {
             FieldDescriptor.SchemaProxy proxy,
             Table table,
             String[] fieldDescriptions,
-            Sort[] sortOrders,
+            @Nullable Sort[] sortOrders,
             Set<RealmFieldType> legalInternalTypes,
             Set<RealmFieldType> legalTerminalTypes,
             String message) {
 
+        //noinspection ConstantConditions
         if (fieldDescriptions == null || fieldDescriptions.length == 0) {
             throw new IllegalArgumentException("You must provide at least one field name.");
         }
@@ -114,7 +118,7 @@ public class SortDescriptor {
     private final long[][] columnIndices;
     private final boolean[] ascendings;
 
-    private SortDescriptor(Table table, long[][] columnIndices, Sort[] sortOrders) {
+    private SortDescriptor(Table table, long[][] columnIndices, @Nullable Sort[] sortOrders) {
         this.table = table;
         this.columnIndices = columnIndices;
         if (sortOrders != null) {

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -600,7 +600,7 @@ public class Table implements TableSchema, NativeObject {
      * @throws io.realm.exceptions.RealmException if it is not possible to set the primary key due to the column
      * not having distinct values (i.e. violating the primary key constraint).
      */
-    public void setPrimaryKey(String columnName) {
+    public void setPrimaryKey(@Nullable String columnName) {
         Table pkTable = getPrimaryKeyTable();
         if (pkTable == null) {
             throw new RealmException("Primary keys are only supported if Table is part of a Group");
@@ -863,7 +863,8 @@ public class Table implements TableSchema, NativeObject {
         return nativeVersion(nativePtr);
     }
 
-    public static String getClassNameForTable(String name) {
+    @Nullable
+    public static String getClassNameForTable(@Nullable String name) {
         if (name == null) { return null; }
         if (!name.startsWith(TABLE_PREFIX)) {
             return name;
@@ -872,6 +873,7 @@ public class Table implements TableSchema, NativeObject {
     }
 
     public static String getTableNameForClass(String name) {
+        //noinspection ConstantConditions
         if (name == null) { return null; }
         if (name.startsWith(TABLE_PREFIX)) {
             return name;
@@ -962,7 +964,7 @@ public class Table implements TableSchema, NativeObject {
 
     public static native void nativeSetLink(long nativeTablePtr, long columnIndex, long rowIndex, long value, boolean isDefault);
 
-    private native long nativeSetPrimaryKey(long privateKeyTableNativePtr, long nativePtr, String columnName);
+    private native long nativeSetPrimaryKey(long privateKeyTableNativePtr, long nativePtr, @Nullable String columnName);
 
     private static native boolean nativeMigratePrimaryKeyTableIfNeeded(long groupNativePtr, long primaryKeyTableNativePtr);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/TableQuery.java
@@ -18,6 +18,8 @@ package io.realm.internal;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import io.realm.Case;
 import io.realm.Sort;
 import io.realm.log.RealmLog;
@@ -247,7 +249,7 @@ public class TableQuery implements NativeObject {
 
     private static final String DATE_NULL_ERROR_MESSAGE = "Date value in query criteria must not be null.";
 
-    public TableQuery equalTo(long[] columnIndex, long[] tablePtrs, Date value) {
+    public TableQuery equalTo(long[] columnIndex, long[] tablePtrs, @Nullable Date value) {
         if (value == null) {
             nativeIsNull(nativePtr, columnIndex, tablePtrs);
         } else {
@@ -258,6 +260,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery notEqualTo(long[] columnIndex, long[] tablePtrs, Date value) {
+        //noinspection ConstantConditions
         if (value == null) { throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE); }
         nativeNotEqualTimestamp(nativePtr, columnIndex, tablePtrs, value.getTime());
         queryValidated = false;
@@ -265,6 +268,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery greaterThan(long[] columnIndex, long[] tablePtrs, Date value) {
+        //noinspection ConstantConditions
         if (value == null) { throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE); }
         nativeGreaterTimestamp(nativePtr, columnIndex, tablePtrs, value.getTime());
         queryValidated = false;
@@ -272,6 +276,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery greaterThanOrEqual(long[] columnIndex, long[] tablePtrs, Date value) {
+        //noinspection ConstantConditions
         if (value == null) { throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE); }
         nativeGreaterEqualTimestamp(nativePtr, columnIndex, tablePtrs, value.getTime());
         queryValidated = false;
@@ -279,6 +284,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery lessThan(long[] columnIndex, long[] tablePtrs, Date value) {
+        //noinspection ConstantConditions
         if (value == null) { throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE); }
         nativeLessTimestamp(nativePtr, columnIndex, tablePtrs, value.getTime());
         queryValidated = false;
@@ -286,6 +292,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery lessThanOrEqual(long[] columnIndex, long[] tablePtrs, Date value) {
+        //noinspection ConstantConditions
         if (value == null) { throw new IllegalArgumentException(DATE_NULL_ERROR_MESSAGE); }
         nativeLessEqualTimestamp(nativePtr, columnIndex, tablePtrs, value.getTime());
         queryValidated = false;
@@ -293,6 +300,7 @@ public class TableQuery implements NativeObject {
     }
 
     public TableQuery between(long[] columnIndex, Date value1, Date value2) {
+        //noinspection ConstantConditions
         if (value1 == null || value2 == null) {
             throw new IllegalArgumentException("Date values in query criteria must not be null."); // Different text
         }
@@ -316,7 +324,7 @@ public class TableQuery implements NativeObject {
     }
 
     // Equals
-    public TableQuery equalTo(long[] columnIndexes, long[] tablePtrs, String value, Case caseSensitive) {
+    public TableQuery equalTo(long[] columnIndexes, long[] tablePtrs, @Nullable String value, Case caseSensitive) {
         nativeEqual(nativePtr, columnIndexes, tablePtrs, value, caseSensitive.getValue());
         queryValidated = false;
         return this;
@@ -329,13 +337,13 @@ public class TableQuery implements NativeObject {
     }
 
     // Not Equals
-    public TableQuery notEqualTo(long[] columnIndex, long[] tablePtrs, String value, Case caseSensitive) {
+    public TableQuery notEqualTo(long[] columnIndex, long[] tablePtrs, @Nullable String value, Case caseSensitive) {
         nativeNotEqual(nativePtr, columnIndex, tablePtrs, value, caseSensitive.getValue());
         queryValidated = false;
         return this;
     }
 
-    public TableQuery notEqualTo(long[] columnIndex, long[] tablePtrs, String value) {
+    public TableQuery notEqualTo(long[] columnIndex, long[] tablePtrs, @Nullable String value) {
         nativeNotEqual(nativePtr, columnIndex, tablePtrs, value, true);
         queryValidated = false;
         return this;
@@ -693,9 +701,9 @@ public class TableQuery implements NativeObject {
 
     private native void nativeNotEqual(long nativeQueryPtr, long[] columnIndices, long[] tablePtrs, byte[] value);
 
-    private native void nativeEqual(long nativeQueryPtr, long[] columnIndexes, long[] tablePtrs, String value, boolean caseSensitive);
+    private native void nativeEqual(long nativeQueryPtr, long[] columnIndexes, long[] tablePtrs, @Nullable String value, boolean caseSensitive);
 
-    private native void nativeNotEqual(long nativeQueryPtr, long[] columnIndex, long[] tablePtrs, String value, boolean caseSensitive);
+    private native void nativeNotEqual(long nativeQueryPtr, long[] columnIndex, long[] tablePtrs, @Nullable String value, boolean caseSensitive);
 
     private native void nativeBeginsWith(long nativeQueryPtr, long[] columnIndices, long[] tablePtrs, String value, boolean caseSensitive);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/UncheckedRow.java
@@ -18,6 +18,8 @@ package io.realm.internal;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmFieldType;
 
 
@@ -114,6 +116,7 @@ public class UncheckedRow implements NativeObject, Row {
 
     @Override
     public long getColumnIndex(String columnName) {
+        //noinspection ConstantConditions
         if (columnName == null) {
             throw new IllegalArgumentException("Column name can not be null.");
         }
@@ -218,6 +221,7 @@ public class UncheckedRow implements NativeObject, Row {
     @Override
     public void setDate(long columnIndex, Date date) {
         parent.checkImmutable();
+        //noinspection ConstantConditions
         if (date == null) {
             throw new IllegalArgumentException("Null Date is not allowed.");
         }
@@ -232,7 +236,7 @@ public class UncheckedRow implements NativeObject, Row {
      * @param value the value to to a row
      */
     @Override
-    public void setString(long columnIndex, String value) {
+    public void setString(long columnIndex, @Nullable String value) {
         parent.checkImmutable();
         if (value == null) {
             getTable().checkDuplicatedNullForPrimaryKeyValue(columnIndex, getIndex());
@@ -244,7 +248,7 @@ public class UncheckedRow implements NativeObject, Row {
     }
 
     @Override
-    public void setBinaryByteArray(long columnIndex, byte[] data) {
+    public void setBinaryByteArray(long columnIndex, @Nullable byte[] data) {
         parent.checkImmutable();
         nativeSetByteArray(nativePtr, columnIndex, data);
     }
@@ -346,7 +350,7 @@ public class UncheckedRow implements NativeObject, Row {
 
     protected native void nativeSetString(long nativeRowPtr, long columnIndex, String value);
 
-    protected native void nativeSetByteArray(long nativePtr, long columnIndex, byte[] data);
+    protected native void nativeSetByteArray(long nativePtr, long columnIndex, @Nullable byte[] data);
 
     protected native void nativeSetLink(long nativeRowPtr, long columnIndex, long value);
 

--- a/realm/realm-library/src/main/java/io/realm/internal/Util.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Util.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.annotation.Nullable;
+
 import io.realm.RealmModel;
 import io.realm.RealmObject;
 import io.realm.log.RealmLog;
@@ -90,13 +92,8 @@ public class Util {
                 || "google_sdk".equals(Build.PRODUCT);
     }
 
-    public static boolean isEmptyString(String str) {
-        if (str == null || str.length() == 0) {
-            return true;
-
-        } else {
-            return false;
-        }
+    public static boolean isEmptyString(@Nullable String str) {
+        return str == null || str.length() == 0;
     }
 
     public static boolean deleteRealm(String canonicalPath, File realmFolder, String realmFileName) {

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidCapabilities.java
@@ -17,6 +17,8 @@ package io.realm.internal.android;
 
 import android.os.Looper;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Capabilities;
 
 
@@ -39,7 +41,7 @@ public class AndroidCapabilities implements Capabilities {
     }
 
     @Override
-    public void checkCanDeliverNotification(String exceptionMessage) {
+    public void checkCanDeliverNotification(@Nullable String exceptionMessage) {
         if (!hasLooper()) {
             throw new IllegalStateException(exceptionMessage == null ? "" : (exceptionMessage + " ") +
                     "Realm cannot be automatically updated on a thread without a looper.");

--- a/realm/realm-library/src/main/java/io/realm/internal/android/AndroidRealmNotifier.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/AndroidRealmNotifier.java
@@ -3,6 +3,8 @@ package io.realm.internal.android;
 import android.os.Handler;
 import android.os.Looper;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Capabilities;
 import io.realm.internal.Keep;
 import io.realm.internal.RealmNotifier;
@@ -16,7 +18,7 @@ import io.realm.internal.SharedRealm;
 public class AndroidRealmNotifier extends RealmNotifier {
     private Handler handler;
 
-    public AndroidRealmNotifier(SharedRealm sharedRealm, Capabilities capabilities) {
+    public AndroidRealmNotifier(@Nullable SharedRealm sharedRealm, Capabilities capabilities) {
         super(sharedRealm);
         if (capabilities.canDeliverNotification()) {
             handler = new Handler(Looper.myLooper());

--- a/realm/realm-library/src/main/java/io/realm/internal/android/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/android/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.internal.android;

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/CompositeMediator.java
@@ -49,6 +49,7 @@ public class CompositeMediator extends RealmProxyMediator {
 
     public CompositeMediator(RealmProxyMediator... mediators) {
         final HashMap<Class<? extends RealmModel>, RealmProxyMediator> tempMediators = new HashMap<>();
+        //noinspection ConstantConditions
         if (mediators != null) {
             for (RealmProxyMediator mediator : mediators) {
                 for (Class<? extends RealmModel> realmClass : mediator.getModelClasses()) {

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/FilterableMediator.java
@@ -60,6 +60,7 @@ public class FilterableMediator extends RealmProxyMediator {
         this.originalMediator = originalMediator;
 
         Set<Class<? extends RealmModel>> tempAllowedClasses = new HashSet<>();
+        //noinspection ConstantConditions
         if (originalMediator != null) {
             Set<Class<? extends RealmModel>> originalClasses = originalMediator.getModelClasses();
             for (Class<? extends RealmModel> clazz : allowedClasses) {

--- a/realm/realm-library/src/main/java/io/realm/internal/modules/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/modules/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.internal.modules;

--- a/realm/realm-library/src/main/java/io/realm/internal/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.internal;

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLog.java
@@ -20,6 +20,8 @@ import android.util.Log;
 
 import java.util.Locale;
 
+import javax.annotation.Nullable;
+
 
 /**
  * Global logger used by all Realm components.
@@ -36,6 +38,7 @@ public final class RealmLog {
      * @param logger the reference to a {@link RealmLogger} implementation.
      */
     public static void add(RealmLogger logger) {
+        //noinspection ConstantConditions
         if (logger == null) {
             throw new IllegalArgumentException("A non-null logger has to be provided");
         }
@@ -66,6 +69,7 @@ public final class RealmLog {
      * @return {@code true} if the logger was removed, {@code false} otherwise.
      */
     public static boolean remove(RealmLogger logger) {
+        //noinspection ConstantConditions
         if (logger == null) {
             throw new IllegalArgumentException("A non-null logger has to be provided");
         }
@@ -115,7 +119,7 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void trace(Throwable throwable, String message, Object... args) {
+    public static void trace(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.TRACE, throwable, message, args);
     }
 
@@ -124,7 +128,7 @@ public final class RealmLog {
      *
      * @param throwable exception to log.
      */
-    public static void debug(Throwable throwable) {
+    public static void debug(@Nullable Throwable throwable) {
         debug(throwable, null);
     }
 
@@ -145,7 +149,7 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void debug(Throwable throwable, String message, Object... args) {
+    public static void debug(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.DEBUG, throwable, message, args);
     }
 
@@ -175,7 +179,7 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void info(Throwable throwable, String message, Object... args) {
+    public static void info(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.INFO, throwable, message, args);
     }
 
@@ -205,7 +209,7 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void warn(Throwable throwable, String message, Object... args) {
+    public static void warn(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.WARN, throwable, message, args);
     }
 
@@ -235,7 +239,7 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void error(Throwable throwable, String message, Object... args) {
+    public static void error(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.ERROR, throwable, message, args);
     }
 
@@ -265,18 +269,18 @@ public final class RealmLog {
      * @param message optional message.
      * @param args optional args used to format the message using {@link String#format(String, Object...)}.
      */
-    public static void fatal(Throwable throwable, String message, Object... args) {
+    public static void fatal(@Nullable Throwable throwable, @Nullable String message, Object... args) {
         log(LogLevel.FATAL, throwable, message, args);
     }
 
     // Formats the message, parses the stacktrace of given throwable and passes them to nativeLog.
-    private static void log(int level, Throwable throwable, String message, Object... args) {
+    private static void log(int level, @Nullable Throwable throwable, @Nullable String message, @Nullable Object... args) {
         if (level < getLevel()) {
             return;
         }
 
         StringBuilder stringBuilder = new StringBuilder();
-        if (args != null && args.length > 0) {
+        if (message != null && args != null && args.length > 0) {
             message = String.format(Locale.US, message, args);
         }
         if (throwable != null) {
@@ -299,14 +303,14 @@ public final class RealmLog {
 
     private static native void nativeRegisterDefaultLogger();
 
-    private static native void nativeLog(int level, String tag, Throwable throwable, String message);
+    private static native void nativeLog(int level, String tag, @Nullable Throwable throwable, @Nullable String message);
 
     private static native void nativeSetLogLevel(int level);
 
     private static native int nativeGetLogLevel();
 
     // Methods below are used for testing core logger bridge only.
-    static native long nativeCreateCoreLoggerBridge(String tag);
+    static native long nativeCreateCoreLoggerBridge(@SuppressWarnings("SameParameterValue") String tag);
 
     static native void nativeCloseCoreLoggerBridge(long nativePtr);
 

--- a/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
+++ b/realm/realm-library/src/main/java/io/realm/log/RealmLogger.java
@@ -16,6 +16,8 @@
 
 package io.realm.log;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Keep;
 
 
@@ -35,5 +37,5 @@ public interface RealmLogger {
      * @param throwable optional exception to log.
      * @param message optional additional message.
      */
-    void log(int level, String tag, Throwable throwable, String message);
+    void log(int level, String tag, @Nullable Throwable throwable, @Nullable String message);
 }

--- a/realm/realm-library/src/main/java/io/realm/log/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/log/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.log;

--- a/realm/realm-library/src/main/java/io/realm/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm;

--- a/realm/realm-library/src/main/java/io/realm/rx/package-info.java
+++ b/realm/realm-library/src/main/java/io/realm/rx/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.rx;

--- a/realm/realm-library/src/objectServer/java/io/realm/ObjectServerError.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ObjectServerError.java
@@ -16,6 +16,8 @@
 
 package io.realm;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.Util;
 
 /**
@@ -61,7 +63,7 @@ public class ObjectServerError extends RuntimeException {
      * @param errorMessage detailed error message.
      * @param exception underlying exception if the error was caused by this.
      */
-    public ObjectServerError(ErrorCode errorCode, String errorMessage, Throwable exception) {
+    public ObjectServerError(ErrorCode errorCode, @Nullable String errorMessage, @Nullable Throwable exception) {
         this.error = errorCode;
         this.errorMessage = errorMessage;
         this.exception = exception;
@@ -74,7 +76,7 @@ public class ObjectServerError extends RuntimeException {
      * @param title Title for this type of error.
      * @param hint a hint for resolving the error.
      */
-    public ObjectServerError(ErrorCode errorCode, String title, String hint) {
+    public ObjectServerError(ErrorCode errorCode, String title, @Nullable String hint) {
         this(errorCode, (hint != null) ? title + " : " + hint : title, (Throwable) null);
     }
 

--- a/realm/realm-library/src/objectServer/java/io/realm/ProgressListener.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/ProgressListener.java
@@ -16,6 +16,7 @@
 
 package io.realm;
 
+
 /**
  * Interface used when interested in updates on data either being uploaded to or downloaded from
  * a Realm Object Server.

--- a/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/RealmFileUserStore.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+import javax.annotation.Nullable;
+
+
 /**
  * A User Store backed by a Realm file to store user.
  */
@@ -39,6 +42,7 @@ public class RealmFileUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public SyncUser getCurrent() {
         String userJson = nativeGetCurrentUser();
         return toSyncUserOrNull(userJson);
@@ -48,6 +52,7 @@ public class RealmFileUserStore implements UserStore {
      * {@inheritDoc}
      */
     @Override
+    @Nullable
     public SyncUser get(String identity, String authUrl) {
         String userJson = nativeGetUser(identity, authUrl);
         return toSyncUserOrNull(userJson);
@@ -85,7 +90,8 @@ public class RealmFileUserStore implements UserStore {
         return nativeIsActive(identity, authenticationUrl);
     }
 
-    private static SyncUser toSyncUserOrNull(String userJson) {
+    @Nullable
+    private static SyncUser toSyncUserOrNull(@Nullable String userJson) {
         if (userJson == null) {
             return null;
         }
@@ -96,6 +102,7 @@ public class RealmFileUserStore implements UserStore {
     protected static native String nativeGetCurrentUser();
 
     // returns json data (token) of the specified user
+    @Nullable
     protected static native String nativeGetUser(String identity, String authUrl);
 
     protected static native String[] nativeGetAllUsers();

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncConfiguration.java
@@ -31,6 +31,8 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import io.realm.annotations.RealmModule;
 import io.realm.exceptions.RealmException;
 import io.realm.internal.RealmProxyMediator;
@@ -82,21 +84,28 @@ public class SyncConfiguration extends RealmConfiguration {
     private final SyncSession.ErrorHandler errorHandler;
     private final boolean deleteRealmOnLogout;
     private final boolean syncClientValidateSsl;
+    @Nullable
     private final String serverCertificateAssetName;
+    @Nullable
     private final String serverCertificateFilePath;
     private final boolean waitForInitialData;
 
     private SyncConfiguration(File directory,
                                 String filename,
                                 String canonicalPath,
+                                @Nullable
                                 String assetFilePath,
+                                @Nullable
                                 byte[] key,
                                 long schemaVersion,
+                                @Nullable
                                 RealmMigration migration,
                                 boolean deleteRealmIfMigrationNeeded,
                                 SharedRealm.Durability durability,
                                 RealmProxyMediator schemaMediator,
+                                @Nullable
                                 RxObservableFactory rxFactory,
+                                @Nullable
                                 Realm.Transaction initialDataTransaction,
                                 boolean readOnly,
                                 SyncUser user,
@@ -104,7 +113,9 @@ public class SyncConfiguration extends RealmConfiguration {
                                 SyncSession.ErrorHandler errorHandler,
                                 boolean deleteRealmOnLogout,
                                 boolean syncClientValidateSsl,
+                                @Nullable
                                 String serverCertificateAssetName,
+                                @Nullable
                                 String serverCertificateFilePath,
                                 boolean waitForInitialData
     ) {
@@ -244,6 +255,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return name of the certificate to be copied from the {@code assets}.
      * @see #getServerCertificateFilePath()
      */
+    @Nullable
     public String getServerCertificateAssetName() {
         return serverCertificateAssetName;
     }
@@ -255,6 +267,7 @@ public class SyncConfiguration extends RealmConfiguration {
      * @return absolute path to the certificate.
      * @see #getServerCertificateAssetName()
      */
+    @Nullable
     public String getServerCertificateFilePath() {
         return serverCertificateFilePath;
     }
@@ -294,11 +307,14 @@ public class SyncConfiguration extends RealmConfiguration {
         private boolean overrideDefaultFolder = false;
         private String fileName;
         private boolean overrideDefaultLocalFileName = false;
+        @Nullable
         private byte[] key;
         private long schemaVersion = 0;
         private HashSet<Object> modules = new HashSet<Object>();
         private HashSet<Class<? extends RealmModel>> debugSchema = new HashSet<Class<? extends RealmModel>>();
+        @Nullable
         private RxObservableFactory rxFactory;
+        @Nullable
         private Realm.Transaction initialDataTransaction;
         private File defaultFolder;
         private String defaultLocalFileName;
@@ -312,7 +328,9 @@ public class SyncConfiguration extends RealmConfiguration {
         private SyncUser user = null;
         private SyncSession.ErrorHandler errorHandler = SyncManager.defaultSessionErrorHandler;
         private boolean syncClientValidateSsl = true;
+        @Nullable
         private String serverCertificateAssetName;
+        @Nullable
         private String serverCertificateFilePath;
 
         /**
@@ -347,6 +365,7 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         Builder(Context context, SyncUser user, String url) {
+            //noinspection ConstantConditions
             if (context == null) {
                 throw new IllegalStateException("Call `Realm.init(Context)` before creating a SyncConfiguration");
             }
@@ -360,6 +379,7 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         private void validateAndSet(SyncUser user) {
+            //noinspection ConstantConditions
             if (user == null) {
                 throw new IllegalArgumentException("Non-null `user` required.");
             }
@@ -370,6 +390,7 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         private void validateAndSet(String uri) {
+            //noinspection ConstantConditions
             if (uri == null) {
                 throw new IllegalArgumentException("Non-null 'uri' required.");
             }
@@ -460,6 +481,7 @@ public class SyncConfiguration extends RealmConfiguration {
          * @throws IllegalArgumentException if file name is {@code null} or empty.
          */
         public Builder name(String filename) {
+            //noinspection ConstantConditions
             if (filename == null || filename.isEmpty()) {
                 throw new IllegalArgumentException("A non-empty filename must be provided");
             }
@@ -482,6 +504,7 @@ public class SyncConfiguration extends RealmConfiguration {
          * @throws IllegalArgumentException if the directory is not valid.
          */
         public Builder directory(File directory) {
+            //noinspection ConstantConditions
             if (directory == null) {
                 throw new IllegalArgumentException("Non-null 'directory' required.");
             }
@@ -509,6 +532,7 @@ public class SyncConfiguration extends RealmConfiguration {
          * @throws IllegalArgumentException if key is invalid.
          */
         public Builder encryptionKey(byte[] key) {
+            //noinspection ConstantConditions
             if (key == null) {
                 throw new IllegalArgumentException("A non-null key must be provided");
             }
@@ -527,12 +551,14 @@ public class SyncConfiguration extends RealmConfiguration {
          * previously configured modules.
          */
         SyncConfiguration.Builder schema(Class<? extends RealmModel> firstClass, Class<? extends RealmModel>... additionalClasses) {
+            //noinspection ConstantConditions
             if (firstClass == null) {
                 throw new IllegalArgumentException("A non-null class must be provided");
             }
             modules.clear();
             modules.add(DEFAULT_MODULE_MEDIATOR);
             debugSchema.add(firstClass);
+            //noinspection ConstantConditions
             if (additionalClasses != null) {
                 Collections.addAll(debugSchema, additionalClasses);
             }
@@ -588,6 +614,7 @@ public class SyncConfiguration extends RealmConfiguration {
         public Builder modules(Object baseModule, Object... additionalModules) {
             modules.clear();
             addModule(baseModule);
+            //noinspection ConstantConditions
             if (additionalModules != null) {
                 for (Object module : additionalModules) {
                     addModule(module);
@@ -642,6 +669,7 @@ public class SyncConfiguration extends RealmConfiguration {
          * @throws IllegalArgumentException if {@code null} is given as an error handler.
          */
         public Builder errorHandler(SyncSession.ErrorHandler errorHandler) {
+            //noinspection ConstantConditions
             if (errorHandler == null) {
                 throw new IllegalArgumentException("Non-null 'errorHandler' required.");
             }
@@ -666,6 +694,7 @@ public class SyncConfiguration extends RealmConfiguration {
          * @see <a href="https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_load_verify_locations.html">SSL_CTX_load_verify_locations</a>
          */
         public Builder trustedRootCA(String filename) {
+            //noinspection ConstantConditions
             if (filename == null || filename.isEmpty()) {
                 throw new IllegalArgumentException("A non-empty filename must be provided");
             }
@@ -866,6 +895,7 @@ public class SyncConfiguration extends RealmConfiguration {
         }
 
         private void addModule(Object module) {
+            //noinspection ConstantConditions
             if (module != null) {
                 checkModule(module);
                 modules.add(module);

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncCredentials.java
@@ -20,6 +20,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
+
 /**
  * Credentials represent a login with a 3rd party login provider in an OAuth2 login flow, and are used by the Realm
  * Object Server to verify the user and grant access.
@@ -142,7 +145,7 @@ public class SyncCredentials {
      * {@link SyncUser#loginAsync(SyncCredentials, String, SyncUser.Callback)}.
      * @throws IllegalArgumentException if any parameter is either {@code null} or empty.
      */
-    public static SyncCredentials custom(String userIdentifier, String identityProvider, Map<String, Object> userInfo) {
+    public static SyncCredentials custom(String userIdentifier, String identityProvider, @Nullable Map<String, Object> userInfo) {
         assertStringNotEmpty(userIdentifier, "userIdentifier");
         assertStringNotEmpty(identityProvider, "identityProvider");
         if (userInfo == null) {
@@ -190,12 +193,13 @@ public class SyncCredentials {
     }
 
     private static void assertStringNotEmpty(String string, String message) {
+        //noinspection ConstantConditions
         if (string == null || "".equals(string)) {
             throw new IllegalArgumentException("Non-null '" + message + "' required.");
         }
     }
 
-    private SyncCredentials(String token, String identityProvider, Map<String, Object> userInfo) {
+    private SyncCredentials(String token, String identityProvider, @Nullable Map<String, Object> userInfo) {
         this.identityProvider = identityProvider;
         this.userIdentifier = token;
         this.userInfo = (userInfo == null) ? new HashMap<String, Object>() : userInfo;

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncManager.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.internal.Keep;
 import io.realm.internal.network.AuthenticationServer;
@@ -136,6 +138,7 @@ public class SyncManager {
      * @throws IllegalArgumentException if {@code userStore} is {@code null}.
      */
     public static void setUserStore(UserStore userStore) {
+        //noinspection ConstantConditions
         if (userStore == null) {
             throw new IllegalArgumentException("Non-null 'userStore' required.");
         }
@@ -150,6 +153,7 @@ public class SyncManager {
      * @throws IllegalArgumentException if {@code listener} is {@code null}.
      */
     public static void addAuthenticationListener(AuthenticationListener listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Non-null 'listener' required.");
         }
@@ -162,6 +166,7 @@ public class SyncManager {
      * @param listener listener to remove.
      */
     public static void removeAuthenticationListener(AuthenticationListener listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             return;
         }
@@ -173,7 +178,7 @@ public class SyncManager {
      *
      * @param errorHandler the default error handler used when interacting with a Realm managed by a Realm Object Server.
      */
-    public static void setDefaultSessionErrorHandler(SyncSession.ErrorHandler errorHandler) {
+    public static void setDefaultSessionErrorHandler(@Nullable SyncSession.ErrorHandler errorHandler) {
         if (errorHandler == null) {
             defaultSessionErrorHandler = SESSION_NO_OP_ERROR_HANDLER;
         } else {
@@ -195,6 +200,7 @@ public class SyncManager {
         // of the native session, the provided Java wrap, helps interact with the native session, when reporting error
         // or requesting an access_token for example.
 
+        //noinspection ConstantConditions
         if (syncConfiguration == null) {
             throw new IllegalArgumentException("A non-empty 'syncConfiguration' is required.");
         }
@@ -218,6 +224,7 @@ public class SyncManager {
      */
     @SuppressWarnings("unused")
     private static synchronized void removeSession(SyncConfiguration syncConfiguration) {
+        //noinspection ConstantConditions
         if (syncConfiguration == null) {
             throw new IllegalArgumentException("A non-empty 'syncConfiguration' is required.");
         }
@@ -285,7 +292,7 @@ public class SyncManager {
      * session to contact. If {@code path == null} all sessions are effected.
      */
     @SuppressWarnings("unused")
-    private static synchronized void notifyErrorHandler(int errorCode, String errorMessage, String path) {
+    private static synchronized void notifyErrorHandler(int errorCode, String errorMessage, @Nullable String path) {
         for (SyncSession syncSession : sessions.values()) {
             if (path == null || path.equals(syncSession.getConfiguration().getPath())) {
                 try {

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncSession.java
@@ -234,6 +234,7 @@ public class SyncSession {
      * @param listener listener to remove.
      */
     public synchronized void removeProgressListener(ProgressListener listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             return;
         }
@@ -275,9 +276,11 @@ public class SyncSession {
     }
 
     private void checkProgressListenerArguments(ProgressMode mode, ProgressListener listener) {
+        //noinspection ConstantConditions
         if (listener == null) {
             throw new IllegalArgumentException("Non-null 'listener' required.");
         }
+        //noinspection ConstantConditions
         if (mode == null) {
             throw new IllegalArgumentException("Non-null 'mode' required.");
         }

--- a/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/SyncUser.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import javax.annotation.Nullable;
+
 import io.realm.internal.RealmNotifier;
 import io.realm.internal.Util;
 import io.realm.internal.android.AndroidCapabilities;
@@ -324,6 +326,7 @@ public class SyncUser {
      * @throws ObjectServerError if the password could not be changed.
      */
     public void changePassword(final String newPassword) throws ObjectServerError {
+        //noinspection ConstantConditions
         if (newPassword == null) {
             throw new IllegalArgumentException("Not-null 'newPassword' required.");
         }
@@ -348,6 +351,7 @@ public class SyncUser {
      * @throws ObjectServerError if the password could not be changed.
      */
     public void changePassword(final String userId, final String newPassword) throws ObjectServerError {
+        //noinspection ConstantConditions
         if (newPassword == null) {
             throw new IllegalArgumentException("Not-null 'newPassword' required.");
         }
@@ -386,6 +390,7 @@ public class SyncUser {
      */
     public RealmAsyncTask changePasswordAsync(final String newPassword, final Callback callback) {
         checkLooperThread("Asynchronous changing password is only possible from looper threads.");
+        //noinspection ConstantConditions
         if (callback == null) {
             throw new IllegalArgumentException("Non-null 'callback' required.");
         }
@@ -415,6 +420,7 @@ public class SyncUser {
      */
     public RealmAsyncTask changePasswordAsync(final String userId, final String newPassword, final Callback callback) {
         checkLooperThread("Asynchronous changing password is only possible from looper threads.");
+        //noinspection ConstantConditions
         if (callback == null) {
             throw new IllegalArgumentException("Non-null 'callback' required.");
         }
@@ -492,6 +498,7 @@ public class SyncUser {
      */
     public RealmAsyncTask retrieveUserAsync(final String provider, final String providerId, final Callback callback) {
         checkLooperThread("Asynchronously retrieving user id is only possible from looper threads.");
+        //noinspection ConstantConditions
         if (callback == null) {
             throw new IllegalArgumentException("Non-null 'callback' required.");
         }
@@ -652,11 +659,12 @@ public class SyncUser {
     // correct thread.
     private static abstract class Request {
 
+        @Nullable
         private final Callback callback;
         private final RealmNotifier handler;
         private final ThreadPoolExecutor networkPoolExecutor;
 
-        public Request(ThreadPoolExecutor networkPoolExecutor, Callback callback) {
+        public Request(ThreadPoolExecutor networkPoolExecutor, @Nullable Callback callback) {
             this.callback = callback;
             this.handler = new AndroidRealmNotifier(null, new AndroidCapabilities());
             this.networkPoolExecutor = networkPoolExecutor;

--- a/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/UserStore.java
@@ -18,6 +18,9 @@ package io.realm;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
+
 /**
  * Interface for classes responsible for saving and retrieving Object Server users again.
  * <p>
@@ -43,6 +46,7 @@ public interface UserStore {
      * This method will throw an exception if more than one valid, logged in users exist.
      * @return {@link SyncUser} object or {@code null} if not found.
      */
+    @Nullable
     SyncUser getCurrent();
 
     /**
@@ -52,6 +56,7 @@ public interface UserStore {
      * @param authenticationUrl the URL of the authentication.
      * @return {@link SyncUser} object or {@code null} if not found.
      */
+    @Nullable
     SyncUser get(String identity, String authenticationUrl);
 
     /**

--- a/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionChange.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionChange.java
@@ -18,6 +18,8 @@ package io.realm.permissions;
 import java.util.Date;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
@@ -67,7 +69,8 @@ public class PermissionChange extends RealmObject {
      *
      * @see <a href="https://realm.io/docs/realm-object-server/#permissions">Controlling Permissions</a>
      */
-    public PermissionChange(String realmUrl, String userId, Boolean mayRead, Boolean mayWrite, Boolean mayManage) {
+    public PermissionChange(String realmUrl, String userId,
+            @Nullable Boolean mayRead, @Nullable Boolean mayWrite, @Nullable Boolean mayManage) {
         this.realmUrl = realmUrl;
         this.userId = userId;
         this.mayRead = mayRead;
@@ -94,10 +97,12 @@ public class PermissionChange extends RealmObject {
      *
      * @return {@code null} if not yet processed. {@code 0} if successful, {@code >0} if an error happened. See {@link #getStatusMessage()}.
      */
+    @Nullable
     public Integer getStatusCode() {
         return statusCode;
     }
 
+    @Nullable
     public String getStatusMessage() {
         return statusMessage;
     }
@@ -110,14 +115,17 @@ public class PermissionChange extends RealmObject {
         return userId;
     }
 
+    @Nullable
     public Boolean mayRead() {
         return mayRead;
     }
 
+    @Nullable
     public Boolean mayWrite() {
         return mayWrite;
     }
 
+    @Nullable
     public Boolean mayManage() {
         return mayManage;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionOffer.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionOffer.java
@@ -18,6 +18,8 @@ package io.realm.permissions;
 import java.util.Date;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.RealmObject;
 import io.realm.annotations.Index;
@@ -68,7 +70,8 @@ public class PermissionOffer extends RealmObject {
      * @param expiresAt When this token will expire and become invalid. Pass {@code null} if this offer should not expire.
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public PermissionOffer(String url, boolean mayRead, boolean mayWrite, boolean mayManage, Date expiresAt) {
+    public PermissionOffer(String url, boolean mayRead, boolean mayWrite, boolean mayManage, @Nullable Date expiresAt) {
+        //noinspection ConstantConditions
         if (url == null) {
             throw new IllegalArgumentException("Non-null 'url' required.");
         }
@@ -98,6 +101,7 @@ public class PermissionOffer extends RealmObject {
      *
      * @return {@code null} if not yet processed. {@code 0} if successful, {@code >0} if an error happened. See {@link #getStatusMessage()}.
      */
+    @Nullable
     public Integer getStatusCode() {
         return statusCode;
     }
@@ -112,10 +116,12 @@ public class PermissionOffer extends RealmObject {
         return statusCode != null && statusCode == 0;
     }
 
+    @Nullable
     public String getStatusMessage() {
         return statusMessage;
     }
 
+    @Nullable
     public String getToken() {
         return token;
     }
@@ -137,6 +143,7 @@ public class PermissionOffer extends RealmObject {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP")
+    @Nullable
     public Date getExpiresAt() {
         return expiresAt;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionOfferResponse.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/permissions/PermissionOfferResponse.java
@@ -18,6 +18,8 @@ package io.realm.permissions;
 import java.util.Date;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
@@ -64,6 +66,7 @@ public class PermissionOfferResponse extends RealmObject {
      *              {@link PermissionOffer}.
      */
     public PermissionOfferResponse(String token) {
+        //noinspection ConstantConditions
         if (token == null) {
             throw new IllegalArgumentException("Non-null 'token' required.");
         }
@@ -93,6 +96,7 @@ public class PermissionOfferResponse extends RealmObject {
      *
      * @return {@code null} if not yet processed. {@code 0} if successful, {@code >0} if an error happened. See {@link #getStatusMessage()}.
      */
+    @Nullable
     public Integer getStatusCode() {
         return statusCode;
     }
@@ -107,6 +111,7 @@ public class PermissionOfferResponse extends RealmObject {
         return statusCode != null && statusCode == 0;
     }
 
+    @Nullable
     public String getStatusMessage() {
         return statusMessage;
     }
@@ -115,6 +120,7 @@ public class PermissionOfferResponse extends RealmObject {
         return token;
     }
 
+    @Nullable
     public String getRealmUrl() {
         return realmUrl;
     }

--- a/realm/realm-library/src/objectServer/java/io/realm/permissions/package-info.java
+++ b/realm/realm-library/src/objectServer/java/io/realm/permissions/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.permissions;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ManagementRealmTests.java
@@ -19,7 +19,6 @@ package io.realm.objectserver;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -32,7 +31,6 @@ import io.realm.Realm;
 import io.realm.RealmChangeListener;
 import io.realm.RealmResults;
 import io.realm.SyncConfiguration;
-import io.realm.SyncCredentials;
 import io.realm.SyncSession;
 import io.realm.SyncUser;
 import io.realm.entities.Dog;
@@ -41,7 +39,6 @@ import io.realm.objectserver.utils.Constants;
 import io.realm.objectserver.utils.UserFactory;
 import io.realm.permissions.PermissionOffer;
 import io.realm.permissions.PermissionOfferResponse;
-import io.realm.rule.RunInLooperThread;
 import io.realm.rule.RunTestInLooperThread;
 
 import static org.junit.Assert.assertEquals;

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/ProgressListenerTests.java
@@ -16,7 +16,6 @@
 
 package io.realm.objectserver;
 
-import android.support.annotation.NonNull;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Rule;
@@ -27,6 +26,8 @@ import java.net.URI;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nonnull;
 
 import io.realm.BaseIntegrationTest;
 import io.realm.Progress;
@@ -55,7 +56,7 @@ public class ProgressListenerTests extends BaseIntegrationTest {
     @Rule
     public TestSyncConfigurationFactory configFactory = new TestSyncConfigurationFactory();
 
-    @NonNull
+    @Nonnull
     private SyncConfiguration createSyncConfig() {
         SyncUser user = UserFactory.createAdminUser(Constants.AUTH_URL);
         return configFactory.createSyncConfigurationBuilder(user, Constants.SYNC_SERVER_URL).build();

--- a/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/package-info.java
+++ b/realm/realm-library/src/syncIntegrationTest/java/io/realm/objectserver/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@javax.annotation.ParametersAreNonnullByDefault
+package io.realm.objectserver;


### PR DESCRIPTION
* add @Nullable annotation to parameters and suppress null related warnings

* add @Nullable annotation to objectserver APIs

* fix compile error in example

* remove @Nullable annotation from equals(Object)

* remove @Nonnull annotation from each overriding methods. Add more package-infos instead.

* remove @Nonnull from parameters

* remove @Nonnull from parameters

* remove @Nonnull from parameters

* remove unused import

* remove unused import

* add 'Nullability by Annotataion' section to CONTRIBUTING.md

* fix typo in CONTRIBUTING.md

* replace 'assert' with 'noinspection' comment

* add more @Nullable annotation to address findbugs warnings