### PR TITLE
Converting examples to RxJava2 (#5141)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ try {
                 }
               } finally {
                 storeJunitResults 'realm/realm-annotations-processor/build/test-results/test/TEST-*.xml'
-                // storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml' FIXME when updating examples
+                storeJunitResults 'examples/unitTestExample/build/test-results/**/TEST-*.xml'
                 step([$class: 'LintPublisher'])
               }
             }

--- a/examples/newsreaderExample/build.gradle
+++ b/examples/newsreaderExample/build.gradle
@@ -13,6 +13,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             // FIXME: Fix the proguard with 3rd party libs
@@ -20,32 +21,39 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
     command {
         monkey.events 2000
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
+
     packagingOptions {
         exclude 'META-INF/services/javax.annotation.processing.Processor'
         exclude 'META-INF/NOTICE'
         exclude 'META-INF/LICENSE'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     //noinspection GradleDependency
     implementation 'com.android.support:appcompat-v7:26.0.1'
     //noinspection GradleDependency
     implementation 'com.android.support:design:26.0.1'
-    implementation 'io.reactivex:rxjava:1.1.0'
-    implementation 'io.reactivex:rxandroid:1.1.0'
-    implementation 'com.squareup.retrofit:retrofit:2.0.0-beta2'
-    implementation 'com.squareup.retrofit:converter-jackson:2.0.0-beta2'
-    implementation 'com.squareup.retrofit:adapter-rxjava:2.0.0-beta2'
     implementation 'com.jakewharton.timber:timber:4.1.0'
     implementation 'com.jakewharton:butterknife:8.5.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
+    implementation 'com.squareup.retrofit2:converter-jackson:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.0'
     implementation 'me.zhanghai.android.materialprogressbar:library:1.1.4'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 }

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/NewsReaderApplication.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/NewsReaderApplication.java
@@ -19,10 +19,9 @@ package io.realm.examples.newsreader;
 import android.app.Application;
 import android.content.Context;
 
+import io.reactivex.plugins.RxJavaPlugins;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
-import rx.plugins.RxJavaErrorHandler;
-import rx.plugins.RxJavaPlugins;
 import timber.log.Timber;
 
 public abstract class NewsReaderApplication extends Application {
@@ -35,13 +34,7 @@ public abstract class NewsReaderApplication extends Application {
         context = this;
 
         initializeTimber();
-        RxJavaPlugins.getInstance().registerErrorHandler(new RxJavaErrorHandler() {
-            @Override
-            public void handleError(Throwable e) {
-                super.handleError(e);
-                Timber.e(e.toString());
-            }
-        });
+        RxJavaPlugins.setErrorHandler(throwable -> Timber.e(throwable.toString()));
 
         // Configure default configuration for Realm
         Realm.init(this);

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/Model.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/Model.java
@@ -22,10 +22,10 @@ import android.text.TextUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.reactivex.Flowable;
+import io.reactivex.Observable;
 import io.realm.RealmResults;
 import io.realm.examples.newsreader.model.entity.NYTimesStory;
-import rx.Observable;
-import rx.functions.Func1;
 
 /**
  * Model class for handling the business rules of the app.
@@ -78,7 +78,7 @@ public class Model {
     /**
      * Returns the news feed for the currently selected category.
      */
-    public Observable<RealmResults<NYTimesStory>> getSelectedNewsFeed() {
+    public Flowable<RealmResults<NYTimesStory>> getSelectedNewsFeed() {
         return repository.loadNewsFeed(selectedSection, false);
     }
 
@@ -106,20 +106,14 @@ public class Model {
     /**
      * Returns the story with the given Id
      */
-    public Observable<NYTimesStory> getStory(@NonNull final String storyId) {
+    public Flowable<NYTimesStory> getStory(@NonNull final String storyId) {
         // Repository is only responsible for loading the data
         // Any validation is done by the model
         // See http://blog.danlew.net/2015/12/08/error-handling-in-rxjava/
         if (TextUtils.isEmpty(storyId)) {
             throw new IllegalArgumentException("Invalid storyId: " + storyId);
         }
-        return repository.loadStory(storyId)
-                .filter(new Func1<NYTimesStory, Boolean>() {
-                    @Override
-                    public Boolean call(NYTimesStory story) {
-                        return story.isValid();
-                    }
-                });
+        return repository.loadStory(storyId).filter(story -> story.isValid());
     }
 
     /**

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesService.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/NYTimesService.java
@@ -19,11 +19,11 @@ package io.realm.examples.newsreader.model.network;
 
 import java.util.List;
 
+import io.reactivex.Observable;
 import io.realm.examples.newsreader.model.entity.NYTimesStory;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.Query;
-import rx.Observable;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 /**
  * Retrofit interface for the New York Times WebService

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/RealmListNYTimesMultimediumDeserializer.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/model/network/RealmListNYTimesMultimediumDeserializer.java
@@ -32,17 +32,17 @@ import io.realm.examples.newsreader.model.entity.NYTimesMultimedium;
 
 public class RealmListNYTimesMultimediumDeserializer extends JsonDeserializer<List<NYTimesMultimedium>> {
 
-    ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
     public RealmListNYTimesMultimediumDeserializer() {
         objectMapper = new ObjectMapper();
     }
 
     @Override
-    public List<NYTimesMultimedium> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    public List<NYTimesMultimedium> deserialize(JsonParser parser, DeserializationContext context) throws IOException {
         RealmList<NYTimesMultimedium> list = new RealmList<>();
 
-        TreeNode treeNode = jp.getCodec().readTree(jp);
+        TreeNode treeNode = parser.getCodec().readTree(parser);
         if (!(treeNode instanceof ArrayNode)) {
             return list;
         }

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/ui/details/DetailsActivity.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/ui/details/DetailsActivity.java
@@ -58,7 +58,7 @@ public class DetailsActivity extends AppCompatActivity {
         // Setup initial views
         setContentView(R.layout.activity_details);
         ButterKnife.bind(this);
-        toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         loaderView.setVisibility(View.VISIBLE);
 

--- a/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/ui/main/MainActivity.java
+++ b/examples/newsreaderExample/src/main/java/io/realm/examples/newsreader/ui/main/MainActivity.java
@@ -58,26 +58,16 @@ public class MainActivity extends AppCompatActivity {
         // Setup initial views
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         //noinspection ConstantConditions
         getSupportActionBar().setDisplayShowTitleEnabled(false);
 
         adapter = null;
-        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                presenter.listItemSelected(position);
-            }
-        });
+        listView.setOnItemClickListener((parent, view, position, id) -> presenter.listItemSelected(position));
         listView.setEmptyView(getLayoutInflater().inflate(R.layout.common_emptylist, listView, false));
 
-        refreshView.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
-            @Override
-            public void onRefresh() {
-                presenter.refreshList();
-            }
-        });
+        refreshView.setOnRefreshListener(() -> presenter.refreshList());
         progressBar.setVisibility(View.INVISIBLE);
 
         // After setup, notify presenter

--- a/examples/rxJavaExample/build.gradle
+++ b/examples/rxJavaExample/build.gradle
@@ -28,11 +28,23 @@ android {
     command {
         monkey.events 2000
     }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    implementation 'io.reactivex:rxandroid:1.1.0'
-    implementation 'io.reactivex:rxjava:1.1.0'
-    implementation 'com.jakewharton.rxbinding:rxbinding:0.3.0'
-    implementation 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.0'
+    implementation 'com.android.support:appcompat-v7:26.0.1'
+    implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
+    implementation 'com.squareup.retrofit2:converter-jackson:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
 }

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/MainActivity.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/MainActivity.java
@@ -19,7 +19,7 @@ package io.realm.examples.rxjava;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.View;
+import android.support.v7.app.AppCompatActivity;
 import android.view.ViewGroup;
 import android.widget.Button;
 
@@ -31,7 +31,7 @@ import io.realm.examples.rxjava.gotchas.GotchasActivity;
 import io.realm.examples.rxjava.retrofit.RetrofitExample;
 import io.realm.examples.rxjava.throttle.ThrottleSearchActivity;
 
-public class MainActivity extends Activity {
+public class MainActivity extends AppCompatActivity {
 
     private ViewGroup container;
     private final TreeMap<String, Class<? extends Activity>> buttons = new TreeMap<String, Class<? extends Activity>>() {{
@@ -45,7 +45,7 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        container = (ViewGroup) findViewById(R.id.list);
+        container = findViewById(R.id.list);
         setupButtons();
     }
 
@@ -53,12 +53,7 @@ public class MainActivity extends Activity {
         for (final Map.Entry<String, Class<? extends Activity>> entry : buttons.entrySet()) {
             Button button = new Button(this);
             button.setText(entry.getKey());
-            button.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    startActivity(entry.getValue());
-                }
-            });
+            button.setOnClickListener(view -> startActivity(entry.getValue()));
             container.addView(button);
         }
     }

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/MyApplication.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/MyApplication.java
@@ -28,7 +28,6 @@ import io.realm.examples.rxjava.model.Person;
 
 public class MyApplication extends Application {
 
-    private static MyApplication context;
     private static final TreeMap<String, String> testPersons = new TreeMap<>();
     static {
         testPersons.put("Chris", null);
@@ -39,12 +38,12 @@ public class MyApplication extends Application {
         testPersons.put("Donn", "donnfelker");
         testPersons.put("Nabil", "nhachicha");
         testPersons.put("Ron", null);
+        testPersons.put("Leonardo", "dalinaum");
     }
 
     @Override
     public void onCreate() {
         super.onCreate();
-        context = this;
         Realm.init(this);
         RealmConfiguration config = new RealmConfiguration.Builder().build();
         Realm.deleteRealm(config);
@@ -54,23 +53,16 @@ public class MyApplication extends Application {
 
     // Create test data
     private void createTestData() {
-        final Random r = new Random(42);
+        final Random random = new Random(42);
         Realm realm = Realm.getDefaultInstance();
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                for (Map.Entry<String, String> entry : testPersons.entrySet()) {
-                    Person p = realm.createObject(Person.class);
-                    p.setName(entry.getKey());
-                    p.setGithubUserName(entry.getValue());
-                    p.setAge(r.nextInt(100));
-                }
+        realm.executeTransaction(r -> {
+            for (Map.Entry<String, String> entry : testPersons.entrySet()) {
+                Person p = r.createObject(Person.class);
+                p.setName(entry.getKey());
+                p.setGithubUserName(entry.getValue());
+                p.setAge(random.nextInt(100));
             }
         });
         realm.close();
-    }
-
-    public static MyApplication getContext() {
-        return context;
     }
 }

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/GitHubApi.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/GitHubApi.java
@@ -16,17 +16,17 @@
 
 package io.realm.examples.rxjava.retrofit;
 
-import retrofit.http.GET;
-import retrofit.http.Path;
-import rx.Observable;
+import io.reactivex.Flowable;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
 
 /**
  * GitHub API definition
  */
-interface GithubApi {
+interface GitHubApi {
     /**
      * See https://developer.github.com/v3/users/
      */
     @GET("/users/{user}")
-    Observable<GitHubUser> user(@Path("user") String user);
+    Flowable<GitHubUser> user(@Path("user") String user);
 }

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/GitHubUser.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/GitHubUser.java
@@ -16,10 +16,13 @@
 
 package io.realm.examples.rxjava.retrofit;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Model class for GitHub users: https://developer.github.com/v3/users/#get-a-single-user
  */
 @SuppressWarnings("unused")
+@JsonIgnoreProperties(ignoreUnknown = true)
 class GitHubUser {
     public String name;
     public int public_repos;

--- a/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/RetrofitExample.java
+++ b/examples/rxJavaExample/src/main/java/io/realm/examples/rxjava/retrofit/RetrofitExample.java
@@ -16,40 +16,41 @@
 
 package io.realm.examples.rxjava.retrofit;
 
-import android.app.Activity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import java.util.Locale;
 
+import io.reactivex.Flowable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
-import io.realm.RealmResults;
 import io.realm.examples.rxjava.R;
 import io.realm.examples.rxjava.model.Person;
-import retrofit.RequestInterceptor;
-import retrofit.RestAdapter;
-import rx.Observable;
-import rx.Subscription;
-import rx.android.schedulers.AndroidSchedulers;
-import rx.functions.Action1;
-import rx.functions.Func1;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import static android.text.TextUtils.isEmpty;
 import static java.lang.String.format;
 
-public class RetrofitExample extends Activity {
+public class RetrofitExample extends AppCompatActivity {
 
     private Realm realm;
-    private Subscription subscription;
+    private Disposable disposable;
     private ViewGroup container;
-    private GithubApi api;
+    private GitHubApi api;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_network);
-        container = (ViewGroup) findViewById(R.id.list);
+        container = findViewById(R.id.list);
         realm = Realm.getDefaultInstance();
         api = createGitHubApi();
     }
@@ -59,57 +60,33 @@ public class RetrofitExample extends Activity {
         super.onResume();
 
         // Load all persons and merge them with their latest stats from GitHub (if they have any)
-        subscription = realm.where(Person.class).isNotNull("githubUserName").findAllSortedAsync("name").asObservable()
-                .filter(new Func1<RealmResults<Person>, Boolean>() {
-                    @Override
-                    public Boolean call(RealmResults<Person> persons) {
-                        // We only want the list once it is loaded.
-                        return persons.isLoaded();
-                    }
-                })
-                .flatMap(new Func1<RealmResults<Person>, Observable<Person>>() {
-                    @Override
-                    public Observable<Person> call(RealmResults<Person> persons) {
-                        // Emit each person individually
-                        return Observable.from(persons);
-                    }
-                })
-                .flatMap(new Func1<Person, Observable<GitHubUser>>() {
-                    @Override
-                    public Observable<GitHubUser> call(Person person) {
-                        // get GitHub statistics. Retrofit automatically does this on a separate thread.
-                        return api.user(person.getGithubUserName());
-                    }
-                })
-                .map(new Func1<GitHubUser, UserViewModel>() {
-                    @Override
-                    public UserViewModel call(GitHubUser gitHubUser) {
-                        // Map Network model to our View model
-                        return new UserViewModel(gitHubUser.name, gitHubUser.public_repos, gitHubUser.public_gists);
-                    }
-                })
-                .observeOn(AndroidSchedulers.mainThread()) // Retrofit put us on a worker thread. Move back to UI
-                .subscribe(new Action1<UserViewModel>() {
-                    @Override
-                    public void call(UserViewModel user) {
-                        // Print user info.
-                        TextView userView = new TextView(RetrofitExample.this);
-                        userView.setText(String.format(Locale.US, "%s : %d/%d",
-                                user.getUsername(), user.getPublicRepos(), user.getPublicGists()));
-                        container.addView(userView);
-                    }
-                }, new Action1<Throwable>() {
-                    @Override
-                    public void call(Throwable throwable) {
-                        throwable.printStackTrace();
-                    }
-                });
+        disposable = realm.where(Person.class).isNotNull("githubUserName").findAllSortedAsync("name").asFlowable()
+                // We only want the list once it is loaded.
+                .filter(people -> people.isLoaded())
+                .switchMap(people -> Flowable.fromIterable(people))
+
+                // get GitHub statistics.
+                .flatMap(person -> api.user(person.getGithubUserName()))
+
+                // Map Network model to our View model
+                .map(gitHubUser -> new UserViewModel(gitHubUser.name, gitHubUser.public_repos, gitHubUser.public_gists))
+
+                // Retrofit put us on a worker thread. Move back to UI
+                .observeOn(AndroidSchedulers.mainThread())
+
+                .subscribe(user -> {
+                    // Print user info.
+                    TextView userView = new TextView(RetrofitExample.this);
+                    userView.setText(
+                            String.format(Locale.US, "%s : %d/%d", user.getUsername(), user.getPublicRepos(), user.getPublicGists()));
+                    container.addView(userView);
+                }, throwable -> throwable.printStackTrace());
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        subscription.unsubscribe();
+        disposable.dispose();
     }
 
     @Override
@@ -118,20 +95,31 @@ public class RetrofitExample extends Activity {
         realm.close();
     }
 
-    private GithubApi createGitHubApi() {
+    private GitHubApi createGitHubApi() {
 
-        RestAdapter.Builder builder = new RestAdapter.Builder().setEndpoint("https://api.github.com/");
+        Retrofit.Builder builder = new Retrofit.Builder()
+                .baseUrl("https://api.github.com/")
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.createWithScheduler(Schedulers.io()))
+                .addConverterFactory(JacksonConverterFactory.create());
 
-        final String githubToken = ""; // Set GitHub OAuth token to avoid throttling if example is used a lot
-        if (!isEmpty(githubToken)) {
-            builder.setRequestInterceptor(new RequestInterceptor() {
-                @Override
-                public void intercept(RequestFacade request) {
-                    request.addHeader("Authorization", format("token %s", githubToken));
-                }
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
+
+        final String gitHubToken = ""; // Set GitHub OAuth token to avoid throttling if example is used a lot
+
+        if (!isEmpty(gitHubToken)) {
+            httpClientBuilder.addInterceptor(chain -> {
+                Request originalRequest = chain.request();
+                Request modifiedRequest = originalRequest
+                        .newBuilder()
+                        .header("Authorization", format("token %s", gitHubToken))
+                        .method(originalRequest.method(), originalRequest.body())
+                        .build();
+                return chain.proceed(modifiedRequest);
             });
         }
 
-        return builder.build().create(GithubApi.class);
+        OkHttpClient httpClient = httpClientBuilder.build();
+        builder.client(httpClient);
+        return builder.build().create(GitHubApi.class);
     }
 }

--- a/examples/rxJavaExample/src/main/res/values/colors.xml
+++ b/examples/rxJavaExample/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimaryDark">#303F9F</color>
+    <color name="colorAccent">#FF4081</color>
+</resources>

--- a/examples/rxJavaExample/src/main/res/values/styles.xml
+++ b/examples/rxJavaExample/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 
 </resources>

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -9,9 +9,9 @@ include 'moduleExample:app'
 include 'moduleExample:library'
 include 'realmModuleExample'
 include 'threadExample'
-//include 'unitTestExample' FIXME: Upgrade to RxJava2
-//include 'newsreaderExample' FIXME: Upgrade to RxJava2
-//include 'rxJavaExample' FIXME: Upgrade to RxJava2
+include 'unitTestExample'
+include 'newsreaderExample'
+include 'rxJavaExample'
 include 'objectServerExample'
 
 rootProject.name = 'realm-examples'

--- a/examples/unitTestExample/build.gradle
+++ b/examples/unitTestExample/build.gradle
@@ -30,11 +30,18 @@ android {
     command {
         monkey.events 2000
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 
 dependencies {
-    testImplementation 'io.reactivex:rxjava:1.1.0'
+    implementation 'com.android.support:appcompat-v7:26.0.1'
+
+    testImplementation 'io.reactivex.rxjava2:rxjava:2.1.0'
 
     // Testing
     testImplementation 'junit:junit:4.12'

--- a/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit4ExampleTest.java
+++ b/examples/unitTestExample/src/androidTest/java/io/realm/examples/unittesting/jUnit4ExampleTest.java
@@ -33,7 +33,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 public class jUnit4ExampleTest {
 
     @Rule
-    public ActivityTestRule<ExampleActivity> mActivityRule = new ActivityTestRule<ExampleActivity>(ExampleActivity.class);
+    public ActivityTestRule<ExampleActivity> mActivityRule = new ActivityTestRule<>(ExampleActivity.class);
 
     @Test
     public void testShouldBeAbleToLaunchActivityAndSeeRealmResults() {

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/ExampleActivity.java
@@ -16,21 +16,18 @@
 
 package io.realm.examples.unittesting;
 
-import android.app.Activity;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
-import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import io.realm.Realm;
-import io.realm.RealmConfiguration;
 import io.realm.RealmResults;
 import io.realm.examples.unittesting.model.Person;
 
-
-public class ExampleActivity extends Activity {
+public class ExampleActivity extends AppCompatActivity {
 
     public static final String TAG = ExampleActivity.class.getName();
     private LinearLayout rootLayout = null;
@@ -42,7 +39,7 @@ public class ExampleActivity extends Activity {
         super.onCreate(savedInstanceState);
         Realm.init(getApplicationContext());
         setContentView(R.layout.activity_example);
-        rootLayout = ((LinearLayout) findViewById(R.id.container));
+        rootLayout = findViewById(R.id.container);
         rootLayout.removeAllViews();
 
         // Open the default Realm for the UI thread.
@@ -71,24 +68,17 @@ public class ExampleActivity extends Activity {
 
         foo.execute();
 
-        findViewById(R.id.clean_up).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                v.setEnabled(false);
-                cleanUp();
-                v.setEnabled(true);
-            }
+        findViewById(R.id.clean_up).setOnClickListener(view -> {
+            view.setEnabled(false);
+            Log.d("TAG", "clean up");
+            cleanUp();
+            view.setEnabled(true);
         });
     }
 
     private void cleanUp() {
         // Delete all persons
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                realm.delete(Person.class);
-            }
-        });
+        realm.executeTransaction(r -> r.delete(Person.class));
     }
 
     @Override
@@ -108,15 +98,12 @@ public class ExampleActivity extends Activity {
         showStatus("Perform basic Create/Read/Update/Delete (CRUD) operations...");
 
         // All writes must be wrapped in a transaction to facilitate safe multi threading
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                // Add a person
-                Person person = realm.createObject(Person.class);
-                person.setId(1);
-                person.setName("John Young");
-                person.setAge(14);
-            }
+        realm.executeTransaction(r -> {
+            // Add a person
+            Person person = r.createObject(Person.class);
+            person.setId(1);
+            person.setName("John Young");
+            person.setAge(14);
         });
 
         // Find the first person (no query conditions) and read a field
@@ -124,28 +111,22 @@ public class ExampleActivity extends Activity {
         showStatus(person.getName() + ":" + person.getAge());
 
         // Update person in a transaction
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                person.setName("John Senior");
-                person.setAge(89);
-            }
+        realm.executeTransaction(r -> {
+            person.setName("John Senior");
+            person.setAge(89);
         });
 
         showStatus(person.getName() + " got older: " + person.getAge());
 
         // Add two more people
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                Person jane = realm.createObject(Person.class);
-                jane.setName("Jane");
-                jane.setAge(27);
+        realm.executeTransaction(r -> {
+            Person jane = r.createObject(Person.class);
+            jane.setName("Jane");
+            jane.setAge(27);
 
-                Person doug = realm.createObject(Person.class);
-                doug.setName("Robert");
-                doug.setAge(42);
-            }
+            Person doug = r.createObject(Person.class);
+            doug.setName("Robert");
+            doug.setAge(42);
         });
 
         RealmResults<Person> people = realm.where(Person.class).findAll();
@@ -164,7 +145,8 @@ public class ExampleActivity extends Activity {
         // Find all persons where age between 1 and 99 and name begins with "J".
         RealmResults<Person> results = realm.where(Person.class)
                 .between("age", 1, 99)       // Notice implicit "and" operation
-                .beginsWith("name", "J").findAll();
+                .beginsWith("name", "J")
+                .findAll();
         status += "\nNumber of people aged between 1 and 99 who's name start with 'J': " + results.size();
 
         realm.close();

--- a/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
+++ b/examples/unitTestExample/src/main/java/io/realm/examples/unittesting/repository/DogRepositoryImpl.java
@@ -19,17 +19,13 @@ package io.realm.examples.unittesting.repository;
 import io.realm.Realm;
 import io.realm.examples.unittesting.model.Dog;
 
-
 public class DogRepositoryImpl implements DogRepository {
     @Override
     public void createDog(final String name) {
         Realm realm = Realm.getDefaultInstance();
-        realm.executeTransaction(new Realm.Transaction() {
-            @Override
-            public void execute(Realm realm) {
-                Dog dog = realm.createObject(Dog.class);
-                dog.setName(name);
-            }
+        realm.executeTransaction(r -> {
+            Dog dog = r.createObject(Dog.class);
+            dog.setName(name);
         });
         realm.close();
     }

--- a/examples/unitTestExample/src/main/res/values/colors.xml
+++ b/examples/unitTestExample/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimaryDark">#303F9F</color>
+    <color name="colorAccent">#FF4081</color>
+</resources>

--- a/examples/unitTestExample/src/main/res/values/styles.xml
+++ b/examples/unitTestExample/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
* Add changelog

* Move Pair into public API (#5081)

* Convert RxJava1 to RxJava2 (#4992)

* Apply rxjava2 to unitTestExample

* Update Jenkinsfile to store junit result of unitTestExample.

* Convert newsreaderExample to RxJava2.

* RxJava2: Add support for changeset observables (#5089)

* Update rxJavaExample and improve some formatting.

* Fix unit testing.

* Fix build.gradle.

* Update build.gradle to fix lint errors.

* Improve some formatting.

* Improve formatting.

* Update style of RxJavaExample.

* Add missing colors.xml file.

* Update styles and colors.

* Rename some disposables.

* PR feedback.

* flatMap -> switchMap and improve formatting.

* Improve formatting.

* Converting newsreaserExample to lambda.

* Improve formatting.

* Improve formatting.

* Apply RxJava2 to unit testing.

* Improve formatting.

* Apply Lambda to rxJavaExample.

* Improve formatting.

* PR feedback

* Re-enable RxJava2 examples

* CompositeDisposable.dispose() -> CompositeDisposable.clear()

* PR feedback.