### PR TITLE
Check and throw when converting String/byte[] (#5263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.0.0-BETA3 (YYYY-MM-DD)
 
+### Bug Fixes
+
+* Throw `IllegalArgumentException` instead of `IllegalStateException` when calling string/binary data setters if the data length exceeds the limit.
+
 ### Breaking Changes
 
 * `RealmResults.distinct()`/`RealmResults.distinctAsync()` have been removed. Use `RealmQuery.distinct()`/`RealmQuery.distinctAsync()` instead.

--- a/realm/realm-library/src/androidTest/AndroidManifest.xml
+++ b/realm/realm-library/src/androidTest/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:targetSdkVersion="22"/>
 
     <application
-        android:debuggable="true">
+        android:debuggable="true"
+        android:largeHeap="true">
         <uses-library android:name="android.test.runner"/>
         <service
             android:name=".services.RemoteProcessService"

--- a/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
+++ b/realm/realm-library/src/main/cpp/io_realm_internal_Table.cpp
@@ -32,6 +32,9 @@ using namespace realm::_impl;
 using namespace realm::jni_util;
 using namespace realm::util;
 
+static_assert(io_realm_internal_Table_MAX_STRING_SIZE == Table::max_string_size, "");
+static_assert(io_realm_internal_Table_MAX_BINARY_SIZE == Table::max_binary_size, "");
+
 static const char* c_null_values_cannot_set_required_msg = "The primary key field '%1' has 'null' values stored.  It "
                                                            "cannot be converted to a '@Required' primary key field.";
 

--- a/realm/realm-library/src/main/cpp/java_accessor.hpp
+++ b/realm/realm-library/src/main/cpp/java_accessor.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include <realm/binary_data.hpp>
+#include <realm/table.hpp>
 
 #include <util/format.hpp>
 
@@ -168,6 +169,14 @@ template <>
 template <>
 inline BinaryData JPrimitiveArrayAccessor<jbyteArray, jbyte>::transform<BinaryData>()
 {
+    // To solve the link issue by directly using Table::max_binary_size
+    static constexpr size_t max_binary_size = Table::max_binary_size;
+
+    if (static_cast<size_t>(m_size) > max_binary_size) {
+        THROW_JAVA_EXCEPTION(m_elements_holder->m_env, JavaExceptionDef::IllegalArgument,
+                             util::format("The length of 'byte[]' value is %1 which exceeds the max binary size %2.",
+                                 m_size, max_binary_size));
+    }
     return is_null() ? realm::BinaryData()
                      : realm::BinaryData(reinterpret_cast<const char*>(m_elements_holder->m_data_ptr), m_size);
 }

--- a/realm/realm-library/src/main/cpp/util.cpp
+++ b/realm/realm-library/src/main/cpp/util.cpp
@@ -427,6 +427,7 @@ transcode_complete : {
 
 
 JStringAccessor::JStringAccessor(JNIEnv* env, jstring str)
+    : m_env(env)
 {
     // For efficiency, if the incoming UTF-16 string is sufficiently
     // small, we will choose an UTF-8 output buffer whose size (in

--- a/realm/realm-library/src/main/cpp/util.hpp
+++ b/realm/realm-library/src/main/cpp/util.hpp
@@ -29,13 +29,16 @@
 #include <realm.hpp>
 #include <realm/lang_bind_helper.hpp>
 #include <realm/timestamp.hpp>
+#include <realm/table.hpp>
 #include <realm/util/safe_int_ops.hpp>
 
 #include <util/format.hpp>
 
 #include "io_realm_internal_Util.h"
 
+#include "java_exception_def.hpp"
 #include "jni_util/log.hpp"
+#include "jni_util/java_exception_thrower.hpp"
 
 #define CHECK_PARAMETERS 1 // Check all parameters in API and throw exceptions in java if invalid
 
@@ -454,10 +457,20 @@ class JStringAccessor {
 public:
     JStringAccessor(JNIEnv*, jstring); // throws
 
-    operator realm::StringData() const noexcept
+    operator realm::StringData() const
     {
+        // To solve the link issue by directly using Table::max_string_size
+        static constexpr size_t max_string_size = realm::Table::max_string_size;
+
         if (m_is_null) {
             return realm::StringData(NULL);
+        }
+        else if (m_size > max_string_size) {
+            THROW_JAVA_EXCEPTION(
+                m_env, realm::_impl::JavaExceptionDef::IllegalArgument,
+                realm::util::format(
+                    "The length of 'String' value in UTF8 encoding is %1 which exceeds the max string length %2.",
+                    m_size, max_string_size));
         }
         else {
             return realm::StringData(m_data.get(), m_size);
@@ -473,6 +486,7 @@ public:
     }
 
 private:
+    JNIEnv* m_env;
     bool m_is_null;
     std::unique_ptr<char[]> m_data;
     std::size_t m_size;

--- a/realm/realm-library/src/main/java/io/realm/internal/Table.java
+++ b/realm/realm-library/src/main/java/io/realm/internal/Table.java
@@ -47,6 +47,9 @@ public class Table implements TableSchema, NativeObject {
     private static final long PRIMARY_KEY_FIELD_COLUMN_INDEX = 1;
     public static final long NO_PRIMARY_KEY = -2;
 
+    public static final int MAX_BINARY_SIZE = 0xFFFFF8 - 8/*array header size*/;
+    public static final int MAX_STRING_SIZE = 0xFFFFF8 - 8/*array header size*/ - 1;
+
     private static final long nativeFinalizerPtr = nativeGetFinalizerPtr();
 
     private final long nativePtr;


### PR DESCRIPTION
Throw IAE if the data length exceeds the limit.